### PR TITLE
Publish releases to four container registries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ docs
 *.iml
 *.log
 deploy.yaml
+gha-creds-*.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quality:
+    name: Validate workflows and release configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate Actions workflows
+        run: >-
+          docker run --rm
+          --volume "${PWD}:/repo"
+          --workdir /repo
+          rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+          -color
+      - name: Check shell scripts
+        run: shellcheck charts/kubert/tests/render.sh scripts/*.sh scripts/tests/*.sh
+      - name: Test release configuration validation
+        run: scripts/tests/verify-release-config-test.sh
+
   test:
     name: Test on Java 17
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: read
+  contents: write
   packages: write
   id-token: write
 
@@ -16,37 +16,97 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish image and chart
+    name: Publish image, chart, and release
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
+    environment: release
+    env:
+      GHCR_IMAGE: ghcr.io/${{ github.repository }}
+      DOCKERHUB_IMAGE: docker.io/${{ vars.DOCKERHUB_NAMESPACE }}/kubert
+      GAR_IMAGE: ${{ vars.GAR_REGISTRY }}/${{ vars.GAR_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/kubert
+      ACR_IMAGE: ${{ vars.ACR_LOGIN_SERVER }}/kubert
     steps:
       - name: Check out source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Verify release versions
+
+      - name: Verify release and registry configuration
         env:
           RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          version="${RELEASE_TAG#v}"
-          grep -Fxq "version: ${version}" charts/kubert/Chart.yaml
-          grep -Fxq "appVersion: \"${version}\"" charts/kubert/Chart.yaml
+          DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          GAR_REGISTRY: ${{ vars.GAR_REGISTRY }}
+          GAR_PROJECT_ID: ${{ vars.GAR_PROJECT_ID }}
+          GAR_REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: scripts/verify-release-config.sh
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Authenticate to Google Cloud with OIDC
+        id: google-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          token_format: access_token
+          create_credentials_file: false
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ vars.GAR_REGISTRY }}
+          username: oauth2accesstoken
+          password: ${{ steps.google-auth.outputs.access_token }}
+
+      - name: Authenticate to Azure with OIDC
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Log in to Azure Container Registry
+        env:
+          ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
+        run: az acr login --name "${ACR_LOGIN_SERVER%%.*}"
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
       - name: Create image metadata
         id: metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/ocularminds/kubert
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GAR_IMAGE }}
+            ${{ env.ACR_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
-      - name: Build and publish image
+
+      - name: Build and publish multi-registry image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -61,17 +121,56 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+
       - name: Set up Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v4.2.0
+
       - name: Package and publish chart
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          package_dir="$(mktemp -d)"
-          helm package charts/kubert --destination "${package_dir}"
+          set -euo pipefail
+          mkdir -p dist
+          helm package charts/kubert --destination dist
           printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io \
             --username "${GITHUB_ACTOR}" \
             --password-stdin
-          helm push "${package_dir}"/kubert-*.tgz oci://ghcr.io/ocularminds/charts
+          helm push dist/kubert-*.tgz oci://ghcr.io/ocularminds/charts
+
+      - name: Create release assets
+        env:
+          IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Kubert ${RELEASE_TAG} container images"
+            echo
+            echo "All registry references use multi-architecture manifest ${IMAGE_DIGEST}."
+            echo
+            echo "${GHCR_IMAGE}:${RELEASE_TAG#v}"
+            echo "${DOCKERHUB_IMAGE}:${RELEASE_TAG#v}"
+            echo "${GAR_IMAGE}:${RELEASE_TAG#v}"
+            echo "${ACR_IMAGE}:${RELEASE_TAG#v}"
+          } > dist/IMAGES.txt
+          (
+            cd dist
+            sha256sum kubert-*.tgz IMAGES.txt > SHA256SUMS
+          )
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" dist/* --clobber
+          else
+            gh release create "${RELEASE_TAG}" dist/* \
+              --generate-notes \
+              --title "Kubert ${RELEASE_TAG#v}" \
+              --verify-tag
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 *.class
 *.jar
 *.tgz
+gha-creds-*.json
 
 .DS_Store
 .idea/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ default `PATCH` policy keeps the first two numeric components fixed; `MINOR`
 keeps the first component fixed, while `MAJOR` permits any newer numeric track.
 Updates also preserve whether the current tag uses a `v` prefix.
 
+## Published artifacts
+
+Each release publishes one `linux/amd64` and `linux/arm64` image manifest to
+GitHub Container Registry, Docker Hub, Google Artifact Registry, and Azure
+Container Registry. Version, major/minor, and `latest` tags all point to the
+same release build. The Helm chart remains available from the GHCR OCI chart
+repository.
+
+Exact image references and their shared manifest digest are attached to each
+GitHub Release as `IMAGES.txt`. See [the release guide](docs/releasing.md) for
+registry configuration, authentication, and verification.
+
 ## Install with Helm
 
 The chart requires Kubernetes 1.29 or newer because it uses the stable native

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,83 @@
+# Releasing Kubert
+
+Kubert releases are built once for `linux/amd64` and `linux/arm64`, then pushed
+to four registries by `.github/workflows/release.yml`. The workflow also pushes
+the Helm chart to GHCR and creates a GitHub Release containing the packaged
+chart, image references, and SHA-256 checksums.
+
+## Release environment
+
+Create a GitHub Actions environment named `release`. Configure its deployment
+policy to allow protected version tags and add approval protection when the
+repository's operating model requires it. Cloud OIDC trust should be restricted
+to this repository and environment; the resulting GitHub subject is:
+
+```text
+repo:ocularminds/kubert:environment:release
+```
+
+Add these environment variables:
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `DOCKERHUB_NAMESPACE` | `ocularminds` | Public Docker Hub namespace |
+| `GAR_REGISTRY` | `europe-west1-docker.pkg.dev` | Artifact Registry hostname |
+| `GAR_PROJECT_ID` | `example-project` | Google Cloud project ID |
+| `GAR_REPOSITORY` | `kubert` | Public Docker repository |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/123/locations/global/workloadIdentityPools/github/providers/kubert` | GitHub OIDC provider |
+| `GCP_SERVICE_ACCOUNT` | `kubert-publisher@example-project.iam.gserviceaccount.com` | Artifact Registry writer |
+| `ACR_LOGIN_SERVER` | `example.azurecr.io` | Public Azure registry hostname |
+
+Add these environment secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `DOCKERHUB_USERNAME` | Docker Hub publisher account |
+| `DOCKERHUB_TOKEN` | Scoped Docker Hub access token with image read/write access |
+| `AZURE_CLIENT_ID` | OIDC-enabled application or managed identity client ID |
+| `AZURE_TENANT_ID` | Microsoft Entra tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Subscription containing the target registry |
+
+`GITHUB_TOKEN` publishes the GitHub image and Helm chart. No long-lived Google
+or Azure credential is stored: GitHub exchanges its OIDC token for short-lived
+cloud credentials during the release job. The workflow validates every setting
+before authenticating or publishing and fails when any registry is omitted.
+
+## Registry access
+
+- Create `docker.io/<DOCKERHUB_NAMESPACE>/kubert` as a public Docker Hub
+  repository and use an organization access token where available.
+- Give the Google service account Artifact Registry Writer only on the selected
+  repository. Grant Artifact Registry Reader to `allUsers` on that repository
+  when unauthenticated pulls are required.
+- Give the Azure identity `AcrPush` only on the selected registry. Anonymous
+  pull requires a Standard or Premium registry and makes every repository in
+  that registry public, so use a dedicated Kubert registry.
+- Confirm the GHCR package visibility is public after its first publication.
+
+## Publish a version
+
+Update both `version` and `appVersion` in `charts/kubert/Chart.yaml`, merge the
+change, and create a matching protected tag from `master`:
+
+```shell
+git tag -s v0.2.0 -m "Kubert 0.2.0"
+git push origin v0.2.0
+```
+
+The tag triggers the release workflow. It publishes `0.2.0`, `0.2`, and
+`latest` tags and creates the GitHub Release only after every registry and the
+Helm chart have accepted their artifacts.
+
+## Verify publication
+
+Use the references in the release's `IMAGES.txt` asset. Each registry should
+resolve the version tag to the manifest digest recorded in that file:
+
+```shell
+docker buildx imagetools inspect <registry-reference>:0.2.0
+helm show chart oci://ghcr.io/ocularminds/charts/kubert --version 0.2.0
+```
+
+Finally, perform an unauthenticated pull from a clean Docker configuration to
+verify that each intended public registry is actually public.

--- a/scripts/tests/verify-release-config-test.sh
+++ b/scripts/tests/verify-release-config-test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+validator="${project_root}/scripts/verify-release-config.sh"
+
+valid_environment=(
+  RELEASE_TAG=v0.2.0
+  DOCKERHUB_NAMESPACE=ocularminds
+  DOCKERHUB_USERNAME=publisher
+  DOCKERHUB_TOKEN=test-token
+  GAR_REGISTRY=europe-west1-docker.pkg.dev
+  GAR_PROJECT_ID=ocularminds-kubert
+  GAR_REPOSITORY=kubert
+  GCP_WORKLOAD_IDENTITY_PROVIDER=projects/123456789/locations/global/workloadIdentityPools/github/providers/kubert
+  GCP_SERVICE_ACCOUNT=publisher@ocularminds-kubert.iam.gserviceaccount.com
+  ACR_LOGIN_SERVER=ocularmindskubert.azurecr.io
+  AZURE_CLIENT_ID=test-client-id
+  AZURE_TENANT_ID=test-tenant-id
+  AZURE_SUBSCRIPTION_ID=test-subscription-id
+)
+
+run_validator() {
+  env "${valid_environment[@]}" "$@" "${validator}" >/dev/null 2>&1
+}
+
+run_validator
+test_count=1
+
+required_values=(
+  RELEASE_TAG
+  DOCKERHUB_NAMESPACE
+  DOCKERHUB_USERNAME
+  DOCKERHUB_TOKEN
+  GAR_REGISTRY
+  GAR_PROJECT_ID
+  GAR_REPOSITORY
+  GCP_WORKLOAD_IDENTITY_PROVIDER
+  GCP_SERVICE_ACCOUNT
+  ACR_LOGIN_SERVER
+  AZURE_CLIENT_ID
+  AZURE_TENANT_ID
+  AZURE_SUBSCRIPTION_ID
+)
+
+for value_name in "${required_values[@]}"; do
+  if run_validator "${value_name}="; then
+    echo "Expected an empty ${value_name} to fail" >&2
+    exit 1
+  fi
+  test_count=$((test_count + 1))
+done
+
+invalid_values=(
+  'RELEASE_TAG=0.2.0'
+  'RELEASE_TAG=v0.2.0-rc.1'
+  'DOCKERHUB_NAMESPACE=OcularMinds'
+  'GAR_REGISTRY=https://europe-west1-docker.pkg.dev'
+  'GAR_PROJECT_ID=INVALID'
+  'GAR_REPOSITORY=invalid/repository'
+  'GCP_WORKLOAD_IDENTITY_PROVIDER=projects/123/providers/kubert'
+  'GCP_SERVICE_ACCOUNT=publisher@example.com'
+  'ACR_LOGIN_SERVER=https://example.azurecr.io'
+  'ACR_LOGIN_SERVER=example.azurecr.io/path'
+)
+
+for invalid_value in "${invalid_values[@]}"; do
+  if run_validator "${invalid_value}"; then
+    echo "Expected ${invalid_value%%=*} validation to fail" >&2
+    exit 1
+  fi
+  test_count=$((test_count + 1))
+done
+
+if run_validator RELEASE_TAG=v9.9.9; then
+  echo "Expected a mismatched chart version to fail" >&2
+  exit 1
+fi
+test_count=$((test_count + 1))
+
+echo "Release configuration tests passed: ${test_count}"

--- a/scripts/verify-release-config.sh
+++ b/scripts/verify-release-config.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+required_values=(
+  RELEASE_TAG
+  DOCKERHUB_NAMESPACE
+  DOCKERHUB_USERNAME
+  DOCKERHUB_TOKEN
+  GAR_REGISTRY
+  GAR_PROJECT_ID
+  GAR_REPOSITORY
+  GCP_WORKLOAD_IDENTITY_PROVIDER
+  GCP_SERVICE_ACCOUNT
+  ACR_LOGIN_SERVER
+  AZURE_CLIENT_ID
+  AZURE_TENANT_ID
+  AZURE_SUBSCRIPTION_ID
+)
+
+for value_name in "${required_values[@]}"; do
+  if [[ -z "${!value_name:-}" ]]; then
+    echo "Missing release environment value: ${value_name}" >&2
+    exit 1
+  fi
+done
+
+require_match() {
+  local value_name="$1"
+  local value="$2"
+  local pattern="$3"
+  if [[ ! "${value}" =~ ${pattern} ]]; then
+    echo "Invalid release environment value: ${value_name}" >&2
+    exit 1
+  fi
+}
+
+require_match RELEASE_TAG "${RELEASE_TAG}" '^v[0-9]+\.[0-9]+\.[0-9]+$'
+require_match DOCKERHUB_NAMESPACE "${DOCKERHUB_NAMESPACE}" '^[a-z0-9]+([._-][a-z0-9]+)*$'
+require_match GAR_REGISTRY "${GAR_REGISTRY}" '^[a-z0-9.-]+-docker\.pkg\.dev$'
+require_match GAR_PROJECT_ID "${GAR_PROJECT_ID}" '^[a-z][a-z0-9-]{4,28}[a-z0-9]$'
+require_match GAR_REPOSITORY "${GAR_REPOSITORY}" '^[a-z0-9][a-z0-9._-]*$'
+require_match GCP_WORKLOAD_IDENTITY_PROVIDER "${GCP_WORKLOAD_IDENTITY_PROVIDER}" '^projects/[0-9]+/locations/global/workloadIdentityPools/[^/]+/providers/[^/]+$'
+require_match GCP_SERVICE_ACCOUNT "${GCP_SERVICE_ACCOUNT}" '^[^@]+@[^@]+\.iam\.gserviceaccount\.com$'
+require_match ACR_LOGIN_SERVER "${ACR_LOGIN_SERVER}" '^[a-z0-9]+\.azurecr\.io$'
+
+version="${RELEASE_TAG#v}"
+chart_file="${project_root}/charts/kubert/Chart.yaml"
+if ! grep -Fxq "version: ${version}" "${chart_file}"; then
+  echo "Chart version does not match ${RELEASE_TAG}" >&2
+  exit 1
+fi
+if ! grep -Fxq "appVersion: \"${version}\"" "${chart_file}"; then
+  echo "Chart appVersion does not match ${RELEASE_TAG}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What changed

- publish one multi-architecture build to GHCR, Docker Hub, Google Artifact Registry, and Azure Container Registry
- authenticate to Google and Azure with environment-scoped OIDC and use a scoped Docker Hub token
- package the Helm chart, attach checksums and image references, and create the GitHub Release after all pushes succeed
- validate workflows, shell scripts, and 25 positive/negative release configuration cases in CI
- document registry roles, public access, environment settings, and verification

## Why

The existing release job only published to GHCR and did not create a GitHub Release. Kubert needs a reproducible release available from four registries without storing long-lived cloud credentials.

## Validation

- `./gradlew clean check --no-daemon`
- `charts/kubert/tests/render.sh`
- `actionlint -shellcheck shellcheck`
- `shellcheck charts/kubert/tests/render.sh scripts/*.sh scripts/tests/*.sh`
- `scripts/tests/verify-release-config-test.sh` (25 cases)
- OSV Scanner: no issues
- Gitleaks: no leaks
- all repository files below 500 LOC