### PR TITLE
Preserve tags when retrying releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing version tag to publish without moving it
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,7 +17,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.release_tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -21,8 +27,9 @@ jobs:
     timeout-minutes: 40
     environment: release
     env:
+      RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
       GHCR_IMAGE: ghcr.io/${{ github.repository }}
-      DOCKERHUB_IMAGE: docker.io/speedo/kubert
+      DOCKERHUB_IMAGE: docker.io/speedoo/kubert
       GAR_REGISTRY: ${{ vars.GAR_REGISTRY }}
       GAR_IMAGE: ${{ vars.GAR_REGISTRY }}/${{ vars.GAR_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/kubert
       ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
@@ -30,10 +37,20 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Resolve immutable release source
+        id: release-source
+        run: |
+          set -euo pipefail
+          tag_revision="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          head_revision="$(git rev-parse HEAD)"
+          test "${tag_revision}" = "${head_revision}"
+          echo "revision=${head_revision}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify release and registry configuration
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           GAR_REGISTRY: ${{ vars.GAR_REGISTRY }}
@@ -116,10 +133,13 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ steps.destinations.outputs.images }}
+          flavor: latest=false
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ env.RELEASE_TAG }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.RELEASE_TAG }}
             type=raw,value=latest
+          labels: |
+            org.opencontainers.image.revision=${{ steps.release-source.outputs.revision }}
 
       - name: Build and publish multi-registry image
         id: build
@@ -132,7 +152,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             VERSION=${{ steps.metadata.outputs.version }}
-            REVISION=${{ github.sha }}
+            REVISION=${{ steps.release-source.outputs.revision }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max
@@ -158,7 +178,6 @@ jobs:
       - name: Create release assets
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           {
@@ -183,7 +202,6 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Updates also preserve whether the current tag uses a `v` prefix.
 ## Published artifacts
 
 Each release publishes one `linux/amd64` and `linux/arm64` image manifest to
-GitHub Container Registry and `docker.io/speedo/kubert`. Google Artifact
+GitHub Container Registry and `docker.io/speedoo/kubert`. Google Artifact
 Registry and Azure Container Registry are included when their OIDC settings
 are configured. Version, major/minor, and `latest` tags all point to the same
 release build. The Helm chart remains available from the GHCR OCI chart

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Releasing Kubert
 
 Kubert releases are built once for `linux/amd64` and `linux/arm64`, then pushed
-to GHCR and `docker.io/speedo/kubert` by `.github/workflows/release.yml`. Google
+to GHCR and `docker.io/speedoo/kubert` by `.github/workflows/release.yml`. Google
 Artifact Registry and Azure Container Registry are optional mirrors. The
 workflow also pushes the Helm chart to GHCR and creates a GitHub Release with
 the packaged chart, image references, and SHA-256 checksums.
@@ -47,7 +47,7 @@ authenticating or publishing.
 
 ## Registry access
 
-- Create `docker.io/speedo/kubert` as a public Docker Hub
+- Create `docker.io/speedoo/kubert` as a public Docker Hub
   repository and use an organization access token where available.
 - Give the Google service account Artifact Registry Writer only on the selected
   repository. Grant Artifact Registry Reader to `allUsers` on that repository
@@ -70,6 +70,18 @@ git push origin v0.2.0
 The tag triggers the release workflow. It publishes `0.2.0`, `0.2`, and
 `latest` tags and creates the GitHub Release only after every configured
 registry and the Helm chart have accepted their artifacts.
+
+If a registry-side problem interrupts publication after the tag is created,
+fix the external configuration and dispatch the reviewed workflow from
+`master` without deleting or moving the tag:
+
+```shell
+gh workflow run Release --ref master -f release_tag=v0.2.0
+```
+
+The recovery path checks out the existing tag, verifies that `HEAD` resolves to
+its commit, and derives both image version and revision from that immutable
+source.
 
 ## Verify publication
 

--- a/scripts/tests/verify-release-config-test.sh
+++ b/scripts/tests/verify-release-config-test.sh
@@ -6,7 +6,7 @@ validator="${project_root}/scripts/verify-release-config.sh"
 
 core_environment=(
   RELEASE_TAG=v0.2.0
-  DOCKERHUB_USER=speedo
+  DOCKERHUB_USER=speedoo
   DOCKERHUB_TOKEN=test-token
 )
 cloud_environment=(


### PR DESCRIPTION
## What changed

- correct the Docker Hub target to the public `docker.io/speedoo/kubert` repository
- add an explicit manual release input for retrying an existing tag
- check out and verify the immutable tagged commit during automatic and manual releases
- derive semver tags and OCI revision from the checked-out release source
- document the tag-preserving recovery command

## Root cause

The v0.2.0 workflow targeted `speedo/kubert`; the actual public repository is `speedoo/kubert`. A normal rerun always uses the workflow stored at the tagged commit, so correcting `master` alone would not repair the existing release without a tag-safe manual path.

## Validation

- `./gradlew clean check --no-daemon`
- `charts/kubert/tests/render.sh`
- `actionlint -shellcheck shellcheck`
- `shellcheck charts/kubert/tests/render.sh scripts/*.sh scripts/tests/*.sh`
- 24 release configuration cases
- OSV Scanner: no issues
- Gitleaks: no leaks
- all files below 500 LOC