### PR TITLE
Add Docker Hub pulls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/ocularminds/kubert/actions/workflows/ci.yml/badge.svg)](https://github.com/ocularminds/kubert/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/ocularminds/kubert/branch/master/graph/badge.svg)](https://codecov.io/gh/ocularminds/kubert)
+[![Docker Pulls](https://img.shields.io/docker/pulls/speedoo/kubert?logo=docker&logoColor=white)](https://hub.docker.com/r/speedoo/kubert)
 [![Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![Kubernetes 1.29+](https://img.shields.io/badge/Kubernetes-1.29%2B-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)
 [![Java 17](https://img.shields.io/badge/Java-17-ED8B00?logo=openjdk&logoColor=white)](https://adoptium.net/)


### PR DESCRIPTION
## What changed

- add a live Docker Pulls badge for the public `speedoo/kubert` image
- link the badge directly to the Docker Hub repository

## Package verification

- no `kubert` or `@ocularminds/kubert` npm package exists
- the `kubert` PyPI package belongs to the unrelated `nginx-architects/kubert` project

The npm and PyPI download badges are intentionally excluded until package names owned by this project are provided, avoiding misleading third-party download attribution.

## Validation

- README diff check passed
- Shields badge endpoint returns HTTP 200
- Docker Hub repository endpoint returns HTTP 200