### PR TITLE
Add Blazra configuration compatibility

### DIFF
--- a/src/main/java/osfx/kubert/config/EnvironmentVariables.java
+++ b/src/main/java/osfx/kubert/config/EnvironmentVariables.java
@@ -1,0 +1,52 @@
+package osfx.kubert.config;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+final class EnvironmentVariables {
+    private static final String CURRENT_PREFIX = "BLAZRA_";
+    private static final String LEGACY_PREFIX = "KUBERT_";
+
+    private final Map<String, String> environment;
+
+    EnvironmentVariables(Map<String, String> environment) {
+        this.environment = Map.copyOf(
+                Objects.requireNonNull(environment, "environment is required"));
+    }
+
+    Optional<String> value(String suffix) {
+        String currentName = currentName(suffix);
+        String legacyName = legacyName(suffix);
+        String currentValue = nonBlank(environment.get(currentName));
+        String legacyValue = nonBlank(environment.get(legacyName));
+
+        if (currentValue != null
+                && legacyValue != null
+                && !currentValue.equals(legacyValue)) {
+            throw new IllegalArgumentException(
+                    currentName + " conflicts with deprecated " + legacyName);
+        }
+        return Optional.ofNullable(currentValue != null ? currentValue : legacyValue);
+    }
+
+    String currentName(String suffix) {
+        return CURRENT_PREFIX + requireSuffix(suffix);
+    }
+
+    private static String legacyName(String suffix) {
+        return LEGACY_PREFIX + requireSuffix(suffix);
+    }
+
+    private static String requireSuffix(String suffix) {
+        Objects.requireNonNull(suffix, "environment variable suffix is required");
+        if (suffix.isBlank()) {
+            throw new IllegalArgumentException("environment variable suffix is required");
+        }
+        return suffix;
+    }
+
+    private static String nonBlank(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/src/main/java/osfx/kubert/config/KubertConfig.java
+++ b/src/main/java/osfx/kubert/config/KubertConfig.java
@@ -53,24 +53,25 @@ public final class KubertConfig {
 
     public static KubertConfig fromEnvironment(Map<String, String> environment) {
         Objects.requireNonNull(environment, "environment is required");
+        EnvironmentVariables variables = new EnvironmentVariables(environment);
         DeploymentTarget target = new DeploymentTarget(
-                environment.getOrDefault("KUBERT_NAMESPACE", "default"),
-                required(environment, "KUBERT_DEPLOYMENT"),
-                required(environment, "KUBERT_CONTAINER"));
+                variables.value("NAMESPACE").orElse("default"),
+                required(variables, "DEPLOYMENT"),
+                required(variables, "CONTAINER"));
         Duration pollInterval = duration(
-                environment,
-                "KUBERT_POLL_INTERVAL",
+                variables,
+                "POLL_INTERVAL",
                 DEFAULT_POLL_INTERVAL);
         Duration connectTimeout = duration(
-                environment,
-                "KUBERT_CONNECT_TIMEOUT",
+                variables,
+                "CONNECT_TIMEOUT",
                 DEFAULT_CONNECT_TIMEOUT);
         Duration requestTimeout = duration(
-                environment,
-                "KUBERT_REQUEST_TIMEOUT",
+                variables,
+                "REQUEST_TIMEOUT",
                 DEFAULT_REQUEST_TIMEOUT);
-        boolean dryRun = booleanValue(environment, "KUBERT_DRY_RUN", false);
-        UpdatePolicy updatePolicy = updatePolicy(environment.get("KUBERT_UPDATE_POLICY"));
+        boolean dryRun = booleanValue(variables, "DRY_RUN", false);
+        UpdatePolicy updatePolicy = updatePolicy(variables.value("UPDATE_POLICY").orElse(null));
         Optional<RegistryCredentials> credentials = credentials(environment);
         return new KubertConfig(
                 target,
@@ -123,39 +124,40 @@ public final class KubertConfig {
         return Optional.of(new RegistryCredentials(identifier, secret));
     }
 
-    private static String required(Map<String, String> environment, String name) {
-        String value = environment.get(name);
-        if (isBlank(value)) {
-            throw new IllegalArgumentException(name + " is required");
-        }
-        return value;
+    private static String required(EnvironmentVariables variables, String suffix) {
+        return variables.value(suffix).orElseThrow(
+                () -> new IllegalArgumentException(variables.currentName(suffix) + " is required"));
     }
 
     private static Duration duration(
-            Map<String, String> environment,
-            String name,
+            EnvironmentVariables variables,
+            String suffix,
             Duration defaultValue) {
-        String value = environment.get(name);
-        if (isBlank(value)) {
+        Optional<String> value = variables.value(suffix);
+        if (value.isEmpty()) {
             return defaultValue;
         }
         try {
-            return Duration.parse(value);
+            return Duration.parse(value.orElseThrow());
         } catch (DateTimeParseException exception) {
-            throw new IllegalArgumentException(name + " must be an ISO-8601 duration", exception);
+            throw new IllegalArgumentException(
+                    variables.currentName(suffix) + " must be an ISO-8601 duration",
+                    exception);
         }
     }
 
     private static boolean booleanValue(
-            Map<String, String> environment,
-            String name,
+            EnvironmentVariables variables,
+            String suffix,
             boolean defaultValue) {
-        String value = environment.get(name);
-        if (isBlank(value)) {
+        Optional<String> configuredValue = variables.value(suffix);
+        if (configuredValue.isEmpty()) {
             return defaultValue;
         }
+        String value = configuredValue.orElseThrow();
         if (!value.equalsIgnoreCase("true") && !value.equalsIgnoreCase("false")) {
-            throw new IllegalArgumentException(name + " must be true or false");
+            throw new IllegalArgumentException(
+                    variables.currentName(suffix) + " must be true or false");
         }
         return Boolean.parseBoolean(value);
     }
@@ -168,7 +170,7 @@ public final class KubertConfig {
             return UpdatePolicy.valueOf(value.toUpperCase(java.util.Locale.ROOT));
         } catch (IllegalArgumentException exception) {
             throw new IllegalArgumentException(
-                    "KUBERT_UPDATE_POLICY must be PATCH, MINOR, or MAJOR",
+                    "BLAZRA_UPDATE_POLICY must be PATCH, MINOR, or MAJOR",
                     exception);
         }
     }

--- a/src/test/java/osfx/kubert/config/EnvironmentVariablesTest.java
+++ b/src/test/java/osfx/kubert/config/EnvironmentVariablesTest.java
@@ -1,0 +1,69 @@
+package osfx.kubert.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentVariablesTest {
+    @Test
+    void resolvesCurrentVariables() {
+        EnvironmentVariables variables = new EnvironmentVariables(Map.of(
+                "BLAZRA_DEPLOYMENT", "api"));
+
+        assertEquals("api", variables.value("DEPLOYMENT").orElseThrow());
+        assertEquals("BLAZRA_DEPLOYMENT", variables.currentName("DEPLOYMENT"));
+    }
+
+    @Test
+    void fallsBackToDeprecatedVariables() {
+        EnvironmentVariables variables = new EnvironmentVariables(Map.of(
+                "BLAZRA_DEPLOYMENT", " ",
+                "KUBERT_DEPLOYMENT", "api"));
+
+        assertEquals("api", variables.value("DEPLOYMENT").orElseThrow());
+    }
+
+    @Test
+    void acceptsMatchingCurrentAndDeprecatedValues() {
+        EnvironmentVariables variables = new EnvironmentVariables(Map.of(
+                "BLAZRA_DEPLOYMENT", "api",
+                "KUBERT_DEPLOYMENT", "api"));
+
+        assertEquals("api", variables.value("DEPLOYMENT").orElseThrow());
+    }
+
+    @Test
+    void treatsBlankValuesAsAbsent() {
+        EnvironmentVariables variables = new EnvironmentVariables(Map.of(
+                "BLAZRA_DEPLOYMENT", " ",
+                "KUBERT_DEPLOYMENT", ""));
+
+        assertTrue(variables.value("DEPLOYMENT").isEmpty());
+    }
+
+    @Test
+    void rejectsConflictsWithoutExposingValues() {
+        EnvironmentVariables variables = new EnvironmentVariables(Map.of(
+                "BLAZRA_DEPLOYMENT", "current-secret-value",
+                "KUBERT_DEPLOYMENT", "legacy-secret-value"));
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> variables.value("DEPLOYMENT"));
+
+        assertEquals(
+                "BLAZRA_DEPLOYMENT conflicts with deprecated KUBERT_DEPLOYMENT",
+                exception.getMessage());
+    }
+
+    @Test
+    void rejectsInvalidConstructionAndSuffixes() {
+        assertThrows(NullPointerException.class, () -> new EnvironmentVariables(null));
+        EnvironmentVariables variables = new EnvironmentVariables(Map.of());
+        assertThrows(NullPointerException.class, () -> variables.value(null));
+        assertThrows(IllegalArgumentException.class, () -> variables.value(" "));
+    }
+}

--- a/src/test/java/osfx/kubert/config/KubertConfigTest.java
+++ b/src/test/java/osfx/kubert/config/KubertConfigTest.java
@@ -15,8 +15,8 @@ class KubertConfigTest {
     @Test
     void loadsSafeDefaults() {
         KubertConfig config = KubertConfig.fromEnvironment(Map.of(
-                "KUBERT_DEPLOYMENT", "api",
-                "KUBERT_CONTAINER", "web"));
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web"));
 
         assertEquals("default", config.target().namespace());
         assertEquals(Duration.ofMinutes(5), config.pollInterval());
@@ -30,14 +30,14 @@ class KubertConfigTest {
     @Test
     void loadsEveryOverride() {
         KubertConfig config = KubertConfig.fromEnvironment(Map.of(
-                "KUBERT_NAMESPACE", "payments",
-                "KUBERT_DEPLOYMENT", "api",
-                "KUBERT_CONTAINER", "web",
-                "KUBERT_POLL_INTERVAL", "PT30S",
-                "KUBERT_CONNECT_TIMEOUT", "PT2S",
-                "KUBERT_REQUEST_TIMEOUT", "PT8S",
-                "KUBERT_DRY_RUN", "TRUE",
-                "KUBERT_UPDATE_POLICY", "minor",
+                "BLAZRA_NAMESPACE", "payments",
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web",
+                "BLAZRA_POLL_INTERVAL", "PT30S",
+                "BLAZRA_CONNECT_TIMEOUT", "PT2S",
+                "BLAZRA_REQUEST_TIMEOUT", "PT8S",
+                "BLAZRA_DRY_RUN", "TRUE",
+                "BLAZRA_UPDATE_POLICY", "minor",
                 "DOCKER_HUB_USERNAME", "robot",
                 "DOCKER_HUB_TOKEN", "secret"));
 
@@ -51,27 +51,63 @@ class KubertConfigTest {
     }
 
     @Test
+    void loadsDeprecatedKubertAliases() {
+        KubertConfig config = KubertConfig.fromEnvironment(Map.of(
+                "KUBERT_NAMESPACE", "legacy",
+                "KUBERT_DEPLOYMENT", "api",
+                "KUBERT_CONTAINER", "web",
+                "KUBERT_POLL_INTERVAL", "PT1M",
+                "KUBERT_CONNECT_TIMEOUT", "PT3S",
+                "KUBERT_REQUEST_TIMEOUT", "PT9S",
+                "KUBERT_DRY_RUN", "true",
+                "KUBERT_UPDATE_POLICY", "major"));
+
+        assertEquals("legacy", config.target().namespace());
+        assertEquals(Duration.ofMinutes(1), config.pollInterval());
+        assertEquals(Duration.ofSeconds(3), config.connectTimeout());
+        assertEquals(Duration.ofSeconds(9), config.requestTimeout());
+        assertTrue(config.dryRun());
+        assertEquals(UpdatePolicy.MAJOR, config.updatePolicy());
+    }
+
+    @Test
+    void rejectsConflictingCurrentAndDeprecatedVariables() {
+        Map<String, String> environment = Map.of(
+                "BLAZRA_DEPLOYMENT", "current-api",
+                "KUBERT_DEPLOYMENT", "legacy-api",
+                "BLAZRA_CONTAINER", "web");
+
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> KubertConfig.fromEnvironment(environment));
+
+        assertEquals(
+                "BLAZRA_DEPLOYMENT conflicts with deprecated KUBERT_DEPLOYMENT",
+                exception.getMessage());
+    }
+
+    @Test
     void rejectsMissingAndPartialConfiguration() {
         assertThrows(IllegalArgumentException.class, () -> KubertConfig.fromEnvironment(Map.of()));
         assertThrows(IllegalArgumentException.class, () -> KubertConfig.fromEnvironment(Map.of(
-                "KUBERT_DEPLOYMENT", "api")));
+                "BLAZRA_DEPLOYMENT", "api")));
         assertThrows(IllegalArgumentException.class, () -> KubertConfig.fromEnvironment(Map.of(
-                "KUBERT_DEPLOYMENT", "api",
-                "KUBERT_CONTAINER", "web",
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web",
                 "DOCKER_HUB_USERNAME", "robot")));
     }
 
     @Test
     void rejectsUnsafeIntervalsAndMalformedValues() {
         for (Map.Entry<String, String> invalid : Map.of(
-                "KUBERT_POLL_INTERVAL", "PT9S",
-                "KUBERT_CONNECT_TIMEOUT", "PT0S",
-                "KUBERT_REQUEST_TIMEOUT", "-PT1S",
-                "KUBERT_DRY_RUN", "yes",
-                "KUBERT_UPDATE_POLICY", "anything").entrySet()) {
+                "BLAZRA_POLL_INTERVAL", "PT9S",
+                "BLAZRA_CONNECT_TIMEOUT", "PT0S",
+                "BLAZRA_REQUEST_TIMEOUT", "-PT1S",
+                "BLAZRA_DRY_RUN", "yes",
+                "BLAZRA_UPDATE_POLICY", "anything").entrySet()) {
             Map<String, String> environment = new HashMap<>();
-            environment.put("KUBERT_DEPLOYMENT", "api");
-            environment.put("KUBERT_CONTAINER", "web");
+            environment.put("BLAZRA_DEPLOYMENT", "api");
+            environment.put("BLAZRA_CONTAINER", "web");
             environment.put(invalid.getKey(), invalid.getValue());
             assertThrows(
                     IllegalArgumentException.class,
@@ -79,9 +115,9 @@ class KubertConfigTest {
                     invalid.getKey());
         }
         Map<String, String> malformed = Map.of(
-                "KUBERT_DEPLOYMENT", "api",
-                "KUBERT_CONTAINER", "web",
-                "KUBERT_POLL_INTERVAL", "five minutes");
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web",
+                "BLAZRA_POLL_INTERVAL", "five minutes");
         assertThrows(IllegalArgumentException.class, () -> KubertConfig.fromEnvironment(malformed));
     }
 }


### PR DESCRIPTION
## What changed

- accept `BLAZRA_*` as the primary runtime configuration namespace
- preserve all existing `KUBERT_*` variables as deprecated aliases
- reject conflicting current and deprecated values without exposing their contents
- isolate environment alias resolution in a single-responsibility configuration object
- add focused coverage for current, legacy, blank, matching, and conflicting inputs

## Why

This is the compatibility foundation for renaming Kubert to Blazra. Supporting both namespaces before changing Helm templates and published artifacts lets existing installations continue to run throughout the staged migration.

## Impact

Existing deployments require no changes. New integrations can begin using `BLAZRA_*`. Helm, chart names, images, documentation, and repository identity remain unchanged in this batch.

## Validation

- `./gradlew clean check --no-daemon`
- 49 Java tests
- 91.07% line coverage and 86.49% branch coverage
- `charts/kubert/tests/render.sh`
- `scripts/tests/verify-release-config-test.sh` (24 tests)
- ShellCheck
- every repository file remains below 500 lines

The optional duplicate local Docker build was not completed because the local daemon was unresponsive; the required GitHub Actions container build and Trivy scan gate this PR.
