### PR TITLE
Add Amazon ECR Public release mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
       GAR_IMAGE: ${{ vars.GAR_REGISTRY }}/${{ vars.GAR_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/blazra
       ACR_LOGIN_SERVER: ${{ vars.ACR_LOGIN_SERVER }}
       ACR_IMAGE: ${{ vars.ACR_LOGIN_SERVER }}/blazra
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
+      ECR_PUBLIC_REGISTRY_ALIAS: ${{ vars.ECR_PUBLIC_REGISTRY_ALIAS }}
+      ECR_PUBLIC_IMAGE: public.ecr.aws/${{ vars.ECR_PUBLIC_REGISTRY_ALIAS }}/blazra
     steps:
       - name: Check out source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,6 +68,9 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+          AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          ECR_PUBLIC_REGISTRY_ALIAS: ${{ vars.ECR_PUBLIC_REGISTRY_ALIAS }}
         run: scripts/verify-release-config.sh
 
       - name: Log in to GitHub Container Registry
@@ -110,6 +117,23 @@ jobs:
         if: ${{ env.ACR_LOGIN_SERVER != '' }}
         run: az acr login --name "${ACR_LOGIN_SERVER%%.*}"
 
+      - name: Authenticate to AWS with OIDC
+        if: ${{ env.AWS_ROLE_TO_ASSUME != '' }}
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          role-session-name: BlazraRelease-${{ github.run_id }}
+          role-duration-seconds: 1800
+          allowed-account-ids: ${{ vars.AWS_ACCOUNT_ID }}
+          mask-aws-account-id: true
+
+      - name: Log in to Amazon ECR Public
+        if: ${{ env.AWS_ROLE_TO_ASSUME != '' }}
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+        with:
+          registry-type: public
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -128,6 +152,9 @@ jobs:
             fi
             if [[ -n "${ACR_LOGIN_SERVER}" ]]; then
               echo "${ACR_IMAGE}"
+            fi
+            if [[ -n "${AWS_ROLE_TO_ASSUME}" ]]; then
+              echo "${ECR_PUBLIC_IMAGE}"
             fi
             echo 'BLAZRA_IMAGES'
           } >> "${GITHUB_OUTPUT}"
@@ -197,6 +224,9 @@ jobs:
             fi
             if [[ -n "${ACR_LOGIN_SERVER}" ]]; then
               echo "${ACR_IMAGE}:${RELEASE_TAG#v}"
+            fi
+            if [[ -n "${AWS_ROLE_TO_ASSUME}" ]]; then
+              echo "${ECR_PUBLIC_IMAGE}:${RELEASE_TAG#v}"
             fi
             echo
             echo "Kubert compatibility aliases:"

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Updates also preserve whether the current tag uses a `v` prefix.
 
 Each release publishes one `linux/amd64` and `linux/arm64` image manifest to
 GitHub Container Registry and `docker.io/speedoo/blazra`. Google Artifact
-Registry and Azure Container Registry are included when their OIDC settings
-are configured. Version, major/minor, and `latest` tags all point to the same
-release build. The Helm chart remains available from the GHCR OCI chart
-repository. During the rename transition, the same image is also published to
-`ghcr.io/ocularminds/kubert` and `docker.io/speedoo/kubert`.
+Registry, Azure Container Registry, and Amazon ECR Public are included when
+their OIDC settings are configured. Version, major/minor, and `latest` tags all
+point to the same release build. The Helm chart remains available from the GHCR
+OCI chart repository. During the rename transition, the same image is also
+published to `ghcr.io/ocularminds/kubert` and `docker.io/speedoo/kubert`.
 
 Exact image references and their shared manifest digest are attached to each
 GitHub Release as `IMAGES.txt`. See [the release guide](docs/releasing.md) for
@@ -53,7 +53,7 @@ Helm 4 is required for an OCI install.
 
 ```shell
 helm install demo oci://ghcr.io/ocularminds/charts/blazra \
-  --version 0.3.0 \
+  --version 0.3.1 \
   --namespace apps \
   --create-namespace \
   --set workload.image.repository=nginx \

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.github.ocularminds'
-version = '0.3.0'
+version = '0.3.1'
 
 java {
     toolchain {

--- a/charts/blazra/Chart.yaml
+++ b/charts/blazra/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: blazra
 description: Run Blazra as a native sidecar beside a single-replica workload
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.3.1
+appVersion: "0.3.1"
 kubeVersion: ">=1.29.0-0"
 home: https://github.com/ocularminds/blazra
 icon: https://raw.githubusercontent.com/ocularminds/blazra/master/docs/blazra.svg

--- a/charts/blazra/tests/render.sh
+++ b/charts/blazra/tests/render.sh
@@ -33,10 +33,10 @@ assert_contains "${test_dir}/default.yaml" "kind: Deployment"
 assert_contains "${test_dir}/default.yaml" "restartPolicy: Always"
 assert_contains "${test_dir}/default.yaml" "resourceNames:"
 assert_contains "${test_dir}/default.yaml" "- demo-blazra"
-assert_contains "${test_dir}/default.yaml" "helm.sh/chart: blazra-0.3.0"
+assert_contains "${test_dir}/default.yaml" "helm.sh/chart: blazra-0.3.1"
 assert_contains "${test_dir}/default.yaml" "app.kubernetes.io/name: blazra"
 assert_contains "${test_dir}/default.yaml" "- name: blazra"
-assert_contains "${test_dir}/default.yaml" "ghcr.io/ocularminds/blazra:0.3.0"
+assert_contains "${test_dir}/default.yaml" "ghcr.io/ocularminds/blazra:0.3.1"
 assert_contains "${test_dir}/default.yaml" "automountServiceAccountToken: false"
 assert_contains "${test_dir}/default.yaml" "runAsUser: 65532"
 assert_contains "${test_dir}/default.yaml" "defaultMode: 0444"
@@ -141,4 +141,4 @@ if helm template legacy-values "${chart_dir}" \
 fi
 
 helm package "${chart_dir}" --destination "${test_dir}" > /dev/null
-[[ -f "${test_dir}/blazra-0.3.0.tgz" ]] || fail "chart package was not created"
+[[ -f "${test_dir}/blazra-0.3.1.tgz" ]] || fail "chart package was not created"

--- a/docs/aws-ecr-public.md
+++ b/docs/aws-ecr-public.md
@@ -1,0 +1,134 @@
+# Amazon ECR Public mirror
+
+Blazra publishes to Amazon ECR Public only when all three AWS release variables
+are configured. Authentication uses GitHub OIDC and temporary credentials; do
+not create IAM access keys for the workflow.
+
+Amazon ECR Public API and authentication operations use `us-east-1`, regardless
+of where consumers run the image.
+
+## 1. Create the public repository
+
+Authenticate the AWS CLI to the account that will own the public image, then
+create the repository:
+
+```shell
+aws ecr-public create-repository \
+  --region us-east-1 \
+  --repository-name blazra
+```
+
+Record the 12-digit AWS account ID and the active registry alias:
+
+```shell
+aws sts get-caller-identity --query Account --output text
+aws ecr-public describe-registries \
+  --region us-east-1 \
+  --query 'registries[0].aliases[?primaryRegistryAlias].name | [0]' \
+  --output text
+```
+
+The resulting image path is `public.ecr.aws/<alias>/blazra`.
+
+## 2. Configure GitHub OIDC trust
+
+Add `https://token.actions.githubusercontent.com` as an IAM OIDC provider with
+audience `sts.amazonaws.com` if the account does not already have it.
+
+Create an IAM role for the release workflow with this trust policy, replacing
+`<account-id>`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:ocularminds/blazra:environment:release"
+        }
+      }
+    }
+  ]
+}
+```
+
+Attach this least-privilege permissions policy, again replacing
+`<account-id>`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GetAuthorizationToken",
+      "Effect": "Allow",
+      "Action": [
+        "ecr-public:GetAuthorizationToken",
+        "sts:GetServiceBearerToken"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PushBlazra",
+      "Effect": "Allow",
+      "Action": [
+        "ecr-public:BatchCheckLayerAvailability",
+        "ecr-public:CompleteLayerUpload",
+        "ecr-public:InitiateLayerUpload",
+        "ecr-public:PutImage",
+        "ecr-public:UploadLayerPart"
+      ],
+      "Resource": "arn:aws:ecr-public::<account-id>:repository/blazra"
+    }
+  ]
+}
+```
+
+The role needs no repository creation, deletion, or policy-management
+permissions.
+
+## 3. Configure the release environment
+
+Set these variables on the existing GitHub `release` environment:
+
+```shell
+gh variable set AWS_ACCOUNT_ID \
+  --repo ocularminds/blazra \
+  --env release \
+  --body '<account-id>'
+gh variable set AWS_ROLE_TO_ASSUME \
+  --repo ocularminds/blazra \
+  --env release \
+  --body 'arn:aws:iam::<account-id>:role/<role-name>'
+gh variable set ECR_PUBLIC_REGISTRY_ALIAS \
+  --repo ocularminds/blazra \
+  --env release \
+  --body '<registry-alias>'
+```
+
+No AWS repository secrets are required. Release validation rejects incomplete
+AWS configuration, malformed account or role values, unexpected image paths,
+and aliases outside the ECR Public naming rules.
+
+## 4. Verify a release
+
+After publishing, confirm anonymous access and both target platforms:
+
+```shell
+docker manifest inspect public.ecr.aws/<alias>/blazra:0.3.1
+```
+
+The ECR Public tag must resolve to the manifest digest recorded in the GitHub
+Release's `IMAGES.txt` asset.
+
+See the official AWS documentation for
+[public registry aliases](https://docs.aws.amazon.com/AmazonECR/latest/public/public-registries.html),
+[pushing public images](https://docs.aws.amazon.com/AmazonECR/latest/public/docker-push-ecr-image.html),
+and [ECR pricing](https://aws.amazon.com/ecr/pricing/).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,10 +2,11 @@
 
 Blazra releases are built once for `linux/amd64` and `linux/arm64`, then pushed
 to GHCR and `docker.io/speedoo/blazra` by `.github/workflows/release.yml`. Google
-Artifact Registry and Azure Container Registry are optional mirrors. The
-workflow also pushes the Helm chart to GHCR and creates a GitHub Release with
-the packaged chart, image references, and SHA-256 checksums. The same manifest
-is pushed to the legacy Kubert GHCR and Docker Hub paths during migration.
+Artifact Registry, Azure Container Registry, and Amazon ECR Public are optional
+mirrors. The workflow also pushes the Helm chart to GHCR and creates a GitHub
+Release with the packaged chart, image references, and SHA-256 checksums. The
+same manifest is pushed to the legacy Kubert GHCR and Docker Hub paths during
+migration.
 
 ## Release environment
 
@@ -28,6 +29,9 @@ Add these optional environment variables to enable the cloud mirrors:
 | `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/123/locations/global/workloadIdentityPools/github/providers/blazra` | GitHub OIDC provider |
 | `GCP_SERVICE_ACCOUNT` | `blazra-publisher@example-project.iam.gserviceaccount.com` | Artifact Registry writer |
 | `ACR_LOGIN_SERVER` | `example.azurecr.io` | Public Azure registry hostname |
+| `AWS_ACCOUNT_ID` | `123456789012` | Account owning the ECR Public repository |
+| `AWS_ROLE_TO_ASSUME` | `arn:aws:iam::123456789012:role/blazra-release` | OIDC release role |
+| `ECR_PUBLIC_REGISTRY_ALIAS` | `example` | Active public registry alias |
 
 Add the Docker Hub values as repository or `release` environment secrets. Add
 the Azure values only when enabling its mirror:
@@ -40,16 +44,16 @@ the Azure values only when enabling its mirror:
 | `AZURE_TENANT_ID` | Microsoft Entra tenant ID |
 | `AZURE_SUBSCRIPTION_ID` | Subscription containing the target registry |
 
-`GITHUB_TOKEN` publishes the GitHub image and Helm chart. No long-lived Google
-or Azure credential is stored: GitHub exchanges its OIDC token for short-lived
-cloud credentials during the release job. The workflow requires Docker Hub and
-validates each optional cloud group as an all-or-nothing configuration before
-authenticating or publishing.
+`GITHUB_TOKEN` publishes the GitHub image and Helm chart. No long-lived Google,
+Azure, or AWS credential is stored: GitHub exchanges its OIDC token for
+short-lived cloud credentials during the release job. The workflow requires
+Docker Hub and validates each optional cloud group as an all-or-nothing
+configuration before authenticating or publishing.
 
 ## Registry access
 
-- Rename the GitHub repository to `ocularminds/blazra` before creating the
-  release tag. Update Google and Azure federated credentials to allow the new
+- Confirm the GitHub repository is `ocularminds/blazra` before creating the
+  release tag. Google, Azure, and AWS federated credentials must allow the
   `repo:ocularminds/blazra:environment:release` subject.
 - Create `docker.io/speedoo/blazra` as a public Docker Hub
   repository and use an organization access token where available. Keep
@@ -62,6 +66,8 @@ authenticating or publishing.
   that registry public, so use a dedicated Blazra registry.
 - Confirm the GHCR package visibility is public after its first publication.
   Keep `ghcr.io/ocularminds/kubert` public as the compatibility alias.
+- Follow the [Amazon ECR Public setup guide](aws-ecr-public.md) to create the
+  public repository and least-privilege OIDC role before enabling that mirror.
 
 ## Publish a version
 
@@ -70,11 +76,11 @@ Update `version` in `build.gradle` plus `version` and `appVersion` in
 tag from `master`:
 
 ```shell
-git tag -s v0.3.0 -m "Blazra 0.3.0"
-git push origin v0.3.0
+git tag -a v0.3.1 -m "Blazra 0.3.1"
+git push origin v0.3.1
 ```
 
-The tag triggers the release workflow. It publishes `0.3.0`, `0.3`, and
+The tag triggers the release workflow. It publishes `0.3.1`, `0.3`, and
 `latest` tags and creates the GitHub Release only after every configured
 registry and the Helm chart have accepted their artifacts.
 
@@ -83,7 +89,7 @@ fix the external configuration and dispatch the reviewed workflow from
 `master` without deleting or moving the tag:
 
 ```shell
-gh workflow run Release --ref master -f release_tag=v0.3.0
+gh workflow run Release --ref master -f release_tag=v0.3.1
 ```
 
 The recovery path checks out the existing tag, verifies that `HEAD` resolves to
@@ -97,11 +103,11 @@ resolve the version tag to the manifest digest recorded in that file. Verify
 both canonical and compatibility paths:
 
 ```shell
-docker buildx imagetools inspect ghcr.io/ocularminds/blazra:0.3.0
-docker buildx imagetools inspect docker.io/speedoo/blazra:0.3.0
-docker buildx imagetools inspect ghcr.io/ocularminds/kubert:0.3.0
-docker buildx imagetools inspect docker.io/speedoo/kubert:0.3.0
-helm show chart oci://ghcr.io/ocularminds/charts/blazra --version 0.3.0
+docker buildx imagetools inspect ghcr.io/ocularminds/blazra:0.3.1
+docker buildx imagetools inspect docker.io/speedoo/blazra:0.3.1
+docker buildx imagetools inspect ghcr.io/ocularminds/kubert:0.3.1
+docker buildx imagetools inspect docker.io/speedoo/kubert:0.3.1
+helm show chart oci://ghcr.io/ocularminds/charts/blazra --version 0.3.1
 ```
 
 Finally, perform an unauthenticated pull from a clean Docker configuration to

--- a/scripts/tests/verify-release-config-test.sh
+++ b/scripts/tests/verify-release-config-test.sh
@@ -6,7 +6,7 @@ validator="${project_root}/scripts/verify-release-config.sh"
 release_workflow="${project_root}/.github/workflows/release.yml"
 
 core_environment=(
-  RELEASE_TAG=v0.3.0
+  RELEASE_TAG=v0.3.1
   GITHUB_REPOSITORY=ocularminds/blazra
   GHCR_IMAGE=ghcr.io/ocularminds/blazra
   GHCR_LEGACY_IMAGE=ghcr.io/ocularminds/kubert
@@ -27,6 +27,10 @@ cloud_environment=(
   AZURE_CLIENT_ID=test-client-id
   AZURE_TENANT_ID=test-tenant-id
   AZURE_SUBSCRIPTION_ID=test-subscription-id
+  AWS_ACCOUNT_ID=123456789012
+  AWS_ROLE_TO_ASSUME=arn:aws:iam::123456789012:role/blazra-release
+  ECR_PUBLIC_REGISTRY_ALIAS=ocularminds
+  ECR_PUBLIC_IMAGE=public.ecr.aws/ocularminds/blazra
 )
 
 run_core_validator() {
@@ -70,6 +74,9 @@ partial_cloud_values=(
   'AZURE_CLIENT_ID=test-client-id'
   'AZURE_TENANT_ID=test-tenant-id'
   'AZURE_SUBSCRIPTION_ID=test-subscription-id'
+  'AWS_ACCOUNT_ID=123456789012'
+  'AWS_ROLE_TO_ASSUME=arn:aws:iam::123456789012:role/blazra-release'
+  'ECR_PUBLIC_REGISTRY_ALIAS=ocularminds'
 )
 for partial_value in "${partial_cloud_values[@]}"; do
   if run_core_validator "${partial_value}"; then
@@ -80,8 +87,8 @@ for partial_value in "${partial_cloud_values[@]}"; do
 done
 
 invalid_values=(
-  'RELEASE_TAG=0.3.0'
-  'RELEASE_TAG=v0.3.0-rc.1'
+  'RELEASE_TAG=0.3.1'
+  'RELEASE_TAG=v0.3.1-rc.1'
   'GITHUB_REPOSITORY=ocularminds/kubert'
   'GHCR_IMAGE=ghcr.io/ocularminds/kubert'
   'GHCR_LEGACY_IMAGE=ghcr.io/ocularminds/blazra'
@@ -96,6 +103,14 @@ invalid_values=(
   'ACR_LOGIN_SERVER=https://example.azurecr.io'
   'ACR_LOGIN_SERVER=example.azurecr.io/path'
   'ACR_IMAGE=ocularmindsblazra.azurecr.io/kubert'
+  'AWS_ACCOUNT_ID=1234'
+  'AWS_ROLE_TO_ASSUME=arn:aws:iam::210987654321:role/blazra-release'
+  'AWS_ROLE_TO_ASSUME=arn:aws:iam::123456789012:user/blazra-release'
+  'ECR_PUBLIC_REGISTRY_ALIAS=a'
+  'ECR_PUBLIC_REGISTRY_ALIAS=AWS-invalid'
+  'ECR_PUBLIC_REGISTRY_ALIAS=a12345678901234567890123456789012345678901234567890'
+  'ECR_PUBLIC_IMAGE='
+  'ECR_PUBLIC_IMAGE=public.ecr.aws/ocularminds/kubert'
 )
 for invalid_value in "${invalid_values[@]}"; do
   if run_full_validator "${invalid_value}"; then
@@ -120,8 +135,16 @@ workflow_expectations=(
   'DOCKERHUB_LEGACY_IMAGE: docker.io/speedoo/kubert'
   'GAR_IMAGE: ${{ vars.GAR_REGISTRY }}/${{ vars.GAR_PROJECT_ID }}/${{ vars.GAR_REPOSITORY }}/blazra'
   'ACR_IMAGE: ${{ vars.ACR_LOGIN_SERVER }}/blazra'
+  'ECR_PUBLIC_IMAGE: public.ecr.aws/${{ vars.ECR_PUBLIC_REGISTRY_ALIAS }}/blazra'
+  'uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3'
+  'uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6'
+  'allowed-account-ids: ${{ vars.AWS_ACCOUNT_ID }}'
+  'role-duration-seconds: 1800'
+  'mask-aws-account-id: true'
   'echo "${GHCR_LEGACY_IMAGE}"'
   'echo "${DOCKERHUB_LEGACY_IMAGE}"'
+  'echo "${ECR_PUBLIC_IMAGE}"'
+  'echo "${ECR_PUBLIC_IMAGE}:${RELEASE_TAG#v}"'
   'helm package charts/blazra --destination dist'
   '--title "Blazra ${RELEASE_TAG#v}"'
 )
@@ -132,5 +155,14 @@ for expected_value in "${workflow_expectations[@]}"; do
   fi
   test_count=$((test_count + 1))
 done
+
+# The search string is a literal expression in the workflow.
+# shellcheck disable=SC2016
+ecr_destination_count="$(grep -Fc 'echo "${ECR_PUBLIC_IMAGE}' "${release_workflow}")"
+if [[ "${ecr_destination_count}" != "2" ]]; then
+  echo "Expected ECR Public in image destinations and release assets" >&2
+  exit 1
+fi
+test_count=$((test_count + 1))
 
 echo "Release configuration tests passed: ${test_count}"

--- a/scripts/verify-release-config.sh
+++ b/scripts/verify-release-config.sh
@@ -54,6 +54,10 @@ require_complete_group Azure \
   AZURE_CLIENT_ID \
   AZURE_TENANT_ID \
   AZURE_SUBSCRIPTION_ID
+require_complete_group "Amazon ECR Public" \
+  AWS_ACCOUNT_ID \
+  AWS_ROLE_TO_ASSUME \
+  ECR_PUBLIC_REGISTRY_ALIAS
 
 require_match() {
   local value_name="$1"
@@ -96,6 +100,19 @@ fi
 if [[ -n "${ACR_LOGIN_SERVER:-}" ]]; then
   require_match ACR_LOGIN_SERVER "${ACR_LOGIN_SERVER}" '^[a-z0-9]+\.azurecr\.io$'
   require_exact ACR_IMAGE "${ACR_IMAGE:-}" "${ACR_LOGIN_SERVER}/blazra"
+fi
+if [[ -n "${AWS_ROLE_TO_ASSUME:-}" ]]; then
+  require_match AWS_ACCOUNT_ID "${AWS_ACCOUNT_ID}" '^[0-9]{12}$'
+  require_match AWS_ROLE_TO_ASSUME "${AWS_ROLE_TO_ASSUME}" \
+    "^arn:aws:iam::${AWS_ACCOUNT_ID}:role/[-A-Za-z0-9+=,.@_/]+$"
+  require_match ECR_PUBLIC_REGISTRY_ALIAS "${ECR_PUBLIC_REGISTRY_ALIAS}" \
+    '^[a-z][a-z0-9]+([._-][a-z0-9]+)*$'
+  if (( ${#ECR_PUBLIC_REGISTRY_ALIAS} > 50 )); then
+    echo "Invalid release environment value: ECR_PUBLIC_REGISTRY_ALIAS" >&2
+    exit 1
+  fi
+  require_exact ECR_PUBLIC_IMAGE "${ECR_PUBLIC_IMAGE:-}" \
+    "public.ecr.aws/${ECR_PUBLIC_REGISTRY_ALIAS}/blazra"
 fi
 
 version="${RELEASE_TAG#v}"


### PR DESCRIPTION
## Summary

- add optional Amazon ECR Public publication using short-lived GitHub OIDC
- pin the AWS credential and ECR login actions by immutable commit
- validate the AWS account, role, registry alias, and canonical image path before authentication
- add a least-privilege AWS setup guide
- prepare release metadata for v0.3.1

## Security and release behavior

- no long-lived AWS access keys or GitHub secrets
- role assumption is restricted to the GitHub release environment
- credentials last 30 minutes, enforce the expected AWS account, and mask the account ID
- ECR configuration is all-or-nothing and optional; existing GHCR and Docker Hub publication is unchanged
- `IMAGES.txt` includes the ECR Public image only when the mirror is enabled

## External setup required before release

- create the public `blazra` repository in Amazon ECR Public
- create the GitHub OIDC role and least-privilege policy described in `docs/aws-ecr-public.md`
- set `AWS_ACCOUNT_ID`, `AWS_ROLE_TO_ASSUME`, and `ECR_PUBLIC_REGISTRY_ALIAS` in the GitHub `release` environment
- do not tag v0.3.1 until those prerequisites are complete

AWS is not authenticated locally and the repository release environment currently has no AWS variables, so this PR intentionally does not publish or tag a release.

## Verification

- `./gradlew clean check installDist --no-daemon`
- `charts/blazra/tests/render.sh`
- `scripts/tests/verify-release-config-test.sh` (66 checks)
- ShellCheck
- actionlint
- staged diff whitespace validation
- all repository files remain below 500 lines