### PR TITLE
Add automated security maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "04:00"
+      timezone: Europe/Stockholm
+    open-pull-requests-limit: 5
+    groups:
+      gradle-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "04:15"
+      timezone: Europe/Stockholm
+    open-pull-requests-limit: 3
+    groups:
+      container-bases:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: deps
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "04:30"
+      timezone: Europe/Stockholm
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         run: shellcheck charts/blazra/tests/render.sh scripts/*.sh scripts/tests/*.sh
       - name: Test release configuration validation
         run: scripts/tests/verify-release-config-test.sh
+      - name: Test security automation configuration
+        run: scripts/tests/verify-security-automation-test.sh
 
   test:
     name: Test on Java 17

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,62 @@
+name: Security
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "17 4 * * 3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Reject vulnerable dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: never
+          show-openssf-scorecard: true
+          show-patched-versions: true
+
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - java-kotlin
+    steps:
+      - name: Check out source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+      - name: Analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ See [`values.yaml`](charts/blazra/values.yaml) for the complete configuration.
   validated. Error messages do not include upstream bodies or credentials.
 - Kubernetes writes use the resource version and re-check the current image to
   avoid overwriting concurrent changes.
+- CodeQL scans Java and GitHub Actions on every change and weekly. Dependency
+  review rejects newly introduced vulnerabilities of moderate severity or
+  higher, while Dependabot groups routine dependency updates by ecosystem.
 
 ## Application configuration
 

--- a/scripts/tests/verify-security-automation-test.sh
+++ b/scripts/tests/verify-security-automation-test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SECURITY_WORKFLOW="${ROOT_DIR}/.github/workflows/security.yml"
+DEPENDABOT_CONFIG="${ROOT_DIR}/.github/dependabot.yml"
+CHECKS=0
+
+fail() {
+  echo "Security automation test failed: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  local description="$3"
+  grep -Fq -- "${expected}" "${file}" || fail "${description}"
+  CHECKS=$((CHECKS + 1))
+}
+
+assert_count() {
+  local file="$1"
+  local expected="$2"
+  local pattern="$3"
+  local description="$4"
+  local actual
+  actual="$(grep -Ec -- "${pattern}" "${file}" || true)"
+  [[ "${actual}" == "${expected}" ]] || fail "${description}: expected ${expected}, got ${actual}"
+  CHECKS=$((CHECKS + 1))
+}
+
+[[ -f "${SECURITY_WORKFLOW}" ]] || fail "security workflow is missing"
+[[ -f "${DEPENDABOT_CONFIG}" ]] || fail "Dependabot configuration is missing"
+
+assert_contains "${SECURITY_WORKFLOW}" "contents: read" \
+  "workflow must default to read-only repository access"
+assert_count "${SECURITY_WORKFLOW}" 1 '^[[:space:]]+security-events: write$' \
+  "only CodeQL may write security events"
+assert_contains "${SECURITY_WORKFLOW}" "github.event_name == 'pull_request'" \
+  "dependency review must run only for pull requests"
+assert_contains "${SECURITY_WORKFLOW}" "fail-on-severity: moderate" \
+  "dependency review must reject moderate or higher vulnerabilities"
+assert_contains "${SECURITY_WORKFLOW}" "comment-summary-in-pr: never" \
+  "dependency review must not require pull-request write access"
+assert_contains "${SECURITY_WORKFLOW}" "- actions" \
+  "CodeQL must scan GitHub Actions"
+assert_contains "${SECURITY_WORKFLOW}" "- java-kotlin" \
+  "CodeQL must scan Java"
+assert_contains "${SECURITY_WORKFLOW}" "queries: security-extended" \
+  "CodeQL must include extended security queries"
+assert_count "${SECURITY_WORKFLOW}" 2 \
+  'github/codeql-action/(init|analyze)@[0-9a-f]{40} # v[0-9]+\.[0-9]+\.[0-9]+$' \
+  "CodeQL actions must be pinned to documented immutable revisions"
+assert_count "${SECURITY_WORKFLOW}" 1 \
+  'actions/dependency-review-action@[0-9a-f]{40} # v[0-9]+\.[0-9]+\.[0-9]+$' \
+  "dependency review must be pinned to a documented immutable revision"
+
+assert_contains "${DEPENDABOT_CONFIG}" "version: 2" \
+  "Dependabot configuration version must be explicit"
+assert_count "${DEPENDABOT_CONFIG}" 1 'package-ecosystem: gradle$' \
+  "Gradle updates must be configured exactly once"
+assert_count "${DEPENDABOT_CONFIG}" 1 'package-ecosystem: docker$' \
+  "Docker updates must be configured exactly once"
+assert_count "${DEPENDABOT_CONFIG}" 1 'package-ecosystem: github-actions$' \
+  "GitHub Actions updates must be configured exactly once"
+assert_count "${DEPENDABOT_CONFIG}" 3 '^[[:space:]]+interval: weekly$' \
+  "all dependency ecosystems must use a weekly schedule"
+assert_count "${DEPENDABOT_CONFIG}" 3 '^[[:space:]]+timezone: Europe/Stockholm$' \
+  "all schedules must use the repository maintenance timezone"
+assert_count "${DEPENDABOT_CONFIG}" 3 '^[[:space:]]+prefix: deps$' \
+  "all automated commits must use the dependency prefix"
+
+echo "Security automation tests passed: ${CHECKS}"


### PR DESCRIPTION
## Summary

- add CodeQL analysis for Java and GitHub Actions on changes and a weekly schedule
- reject pull requests that introduce dependencies with moderate-or-higher known vulnerabilities
- enable grouped weekly Dependabot updates for Gradle, Docker, and GitHub Actions
- pin every new third-party action by immutable commit and use least-privilege workflow permissions
- add 17 configuration assertions to prevent silent security-policy regression

## Why

Blazra already scans built containers and locks dependencies, but the repository had no CodeQL configuration, dependency-change gate, or automated update policy. This batch adds those controls without changing runtime behavior or release versions.

## Security behavior

- CodeQL uses the extended security query suite for both supported languages
- only the CodeQL job receives `security-events: write`; the workflow defaults to `contents: read`
- dependency review does not receive pull-request write access and therefore cannot post comments
- routine updates are grouped by ecosystem to reduce review noise, while major updates remain isolated for Gradle and Actions

## Verification

- `./gradlew clean check installDist --no-daemon`
- `charts/blazra/tests/render.sh`
- `scripts/tests/verify-release-config-test.sh` (66 checks)
- `scripts/tests/verify-security-automation-test.sh` (17 checks)
- ShellCheck
- actionlint
- Dependabot YAML parse validation
- whitespace validation
- all repository files remain below 500 lines
