### PR TITLE
Support public OCI registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@
 [![Kubernetes 1.29+](https://img.shields.io/badge/Kubernetes-1.29%2B-326CE5?logo=kubernetes&logoColor=white)](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)
 [![Java 17](https://img.shields.io/badge/Java-17-ED8B00?logo=openjdk&logoColor=white)](https://adoptium.net/)
 
-Blazra watches one container in a Kubernetes Deployment and updates its Docker
-Hub image when a newer numeric tag is available. The Helm chart runs Blazra as
-a Kubernetes-native sidecar beside that workload and grants access to exactly
-one Deployment.
+Blazra watches one container in a Kubernetes Deployment and updates its image
+when a newer numeric tag is available. It supports Docker Hub and anonymous
+public OCI Distribution registries, including GHCR and ECR Public. The Helm
+chart runs Blazra as a Kubernetes-native sidecar beside that workload and
+grants access to exactly one Deployment.
 
 Supported tags contain two to four numeric components, with an optional `v`
-prefix—for example `1.4`, `v2.3.1`, or `3.1.0.12`. Digests, non-Docker Hub
-registries, and non-numeric release tags are deliberately left unchanged. The
-default `PATCH` policy keeps the first two numeric components fixed; `MINOR`
-keeps the first component fixed, while `MAJOR` permits any newer numeric track.
-Updates also preserve whether the current tag uses a `v` prefix.
+prefix—for example `1.4`, `v2.3.1`, or `3.1.0.12`. Digests, private non-Docker
+Hub registries, and non-numeric release tags are deliberately left unchanged.
+The default `PATCH` policy keeps the first two numeric components fixed;
+`MINOR` keeps the first component fixed, while `MAJOR` permits any newer
+numeric track. Updates also preserve whether the current tag uses a `v` prefix.
 
 ## Published artifacts
 
@@ -68,7 +69,7 @@ helm install demo ./charts/blazra --namespace apps --create-namespace
 ```
 
 The chart is intentionally limited to one workload replica. A sidecar runs in
-every Pod, so additional replicas would duplicate Docker Hub and Kubernetes API
+every Pod, so additional replicas would duplicate registry and Kubernetes API
 traffic. The values schema rejects replica counts other than one.
 
 ### Existing workloads
@@ -97,11 +98,31 @@ Use a scoped Docker Hub access token, never an account password. The chart does
 not accept secret values directly, so they cannot be persisted in Helm release
 values.
 
+### Public OCI registries
+
+Use a fully qualified repository for public GHCR, Google Artifact Registry,
+Azure Container Registry, Amazon ECR Public, or another OCI Distribution
+registry. For example:
+
+```yaml
+workload:
+  image:
+    repository: public.ecr.aws/example/team/app
+    tag: 1.2.3
+```
+
+Anonymous registries may issue a short-lived bearer token challenge. Blazra
+accepts that flow only when the token service uses the registry's own HTTPS
+origin. Registry names must be fully qualified public DNS names; literal IP,
+localhost, `.local`, and `.internal` destinations are rejected. Private OCI
+registry credentials are not yet supported; Docker Hub credentials remain
+isolated to Docker Hub requests.
+
 ## Important values
 
 | Value | Default | Purpose |
 | --- | --- | --- |
-| `workload.image.repository` | `nginx` | Docker Hub workload repository |
+| `workload.image.repository` | `nginx` | Docker Hub or fully qualified public OCI repository |
 | `workload.image.tag` | `1.30.4` | Initial numeric workload tag |
 | `workload.image.digest` | empty | Immutable workload digest; disables updates while set |
 | `workload.containerName` | `app` | Container Blazra is allowed to update |
@@ -126,8 +147,9 @@ See [`values.yaml`](charts/blazra/values.yaml) for the complete configuration.
   profile.
 - The runtime image is shell-free and distroless. Build and runtime bases are
   pinned by digest, while release images include provenance and an SBOM.
-- Docker Hub responses, pagination, timeouts, and origin are bounded and
-  validated. Error messages do not include upstream bodies or credentials.
+- Registry responses, pagination, timeouts, bearer tokens, and origins are
+  bounded and validated. Error messages do not include upstream bodies or
+  credentials, and Docker Hub credentials are never routed to another host.
 - Kubernetes writes use the resource version and re-check the current image to
   avoid overwriting concurrent changes.
 - CodeQL scans Java and GitHub Actions on every change and weekly. Dependency
@@ -146,8 +168,8 @@ running the image directly.
 | `BLAZRA_NAMESPACE` | No | `default` | Deployment namespace |
 | `BLAZRA_POLL_INTERVAL` | No | `PT5M` | ISO-8601 duration, 10 seconds to 24 hours |
 | `BLAZRA_UPDATE_POLICY` | No | `PATCH` | Maximum allowed version scope: `PATCH`, `MINOR`, or `MAJOR` |
-| `BLAZRA_CONNECT_TIMEOUT` | No | `PT5S` | Docker Hub connection timeout |
-| `BLAZRA_REQUEST_TIMEOUT` | No | `PT15S` | Docker Hub request timeout |
+| `BLAZRA_CONNECT_TIMEOUT` | No | `PT5S` | Registry connection timeout |
+| `BLAZRA_REQUEST_TIMEOUT` | No | `PT15S` | Registry request timeout |
 | `BLAZRA_DRY_RUN` | No | `false` | Report updates without writing them |
 | `DOCKER_HUB_USERNAME` | No | — | Configure together with the token |
 | `DOCKER_HUB_TOKEN` | No | — | Scoped Docker Hub access token |
@@ -163,7 +185,8 @@ the update policy:
 
 - `model` owns validated, immutable domain values.
 - `service` owns image selection and update orchestration.
-- `registry` adapts the Docker Hub API.
+- `registry` routes Docker Hub to its dedicated adapter and other public images
+  to a bounded OCI Distribution adapter.
 - `repository` adapts Kubernetes with optimistic concurrency.
 - `runtime` schedules non-overlapping checks.
 - `config` validates all input before startup.

--- a/charts/blazra/tests/render.sh
+++ b/charts/blazra/tests/render.sh
@@ -86,6 +86,13 @@ helm template pinned "${chart_dir}" \
 assert_contains "${test_dir}/pinned.yaml" "nginx@${digest}"
 assert_contains "${test_dir}/pinned.yaml" "ghcr.io/ocularminds/blazra@${digest}"
 
+helm template public-oci "${chart_dir}" \
+  --kube-version 1.29.0 \
+  --set workload.image.repository=public.ecr.aws/example/team/app \
+  --set workload.image.tag=1.2.3 > "${test_dir}/public-oci.yaml"
+
+assert_contains "${test_dir}/public-oci.yaml" "public.ecr.aws/example/team/app:1.2.3"
+
 helm template external-access "${chart_dir}" \
   --namespace apps \
   --kube-version 1.29.0 \

--- a/src/main/java/io/github/ocularminds/blazra/BlazraApplication.java
+++ b/src/main/java/io/github/ocularminds/blazra/BlazraApplication.java
@@ -6,10 +6,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import io.github.ocularminds.blazra.config.BlazraConfig;
 import io.github.ocularminds.blazra.registry.DockerHubRegistryClient;
+import io.github.ocularminds.blazra.registry.OciRegistryClient;
+import io.github.ocularminds.blazra.registry.RegistryClient;
+import io.github.ocularminds.blazra.registry.RegistryClientRouter;
 import io.github.ocularminds.blazra.repository.kubernetes.Fabric8DeploymentRepository;
 import io.github.ocularminds.blazra.runtime.PollingRunner;
 import io.github.ocularminds.blazra.service.DeploymentMonitor;
-import io.github.ocularminds.blazra.service.DockerHubImageResolver;
+import io.github.ocularminds.blazra.service.RegistryImageResolver;
 
 public final class BlazraApplication {
     private static final Logger LOGGER = Logger.getLogger(BlazraApplication.class.getName());
@@ -34,13 +37,15 @@ public final class BlazraApplication {
 
     static void run(BlazraConfig config) throws InterruptedException {
         try (KubernetesClient kubernetesClient = new KubernetesClientBuilder().build()) {
-            DockerHubRegistryClient registryClient = new DockerHubRegistryClient(
-                    config.registryCredentials(),
-                    config.connectTimeout(),
-                    config.requestTimeout());
+            RegistryClient registryClient = new RegistryClientRouter(
+                    new DockerHubRegistryClient(
+                            config.registryCredentials(),
+                            config.connectTimeout(),
+                            config.requestTimeout()),
+                    new OciRegistryClient(config.connectTimeout(), config.requestTimeout()));
             DeploymentMonitor monitor = new DeploymentMonitor(
                     new Fabric8DeploymentRepository(kubernetesClient),
-                    new DockerHubImageResolver(registryClient, config.updatePolicy()),
+                    new RegistryImageResolver(registryClient, config.updatePolicy()),
                     config.target(),
                     config.dryRun());
             try (PollingRunner runner = new PollingRunner(monitor, config.pollInterval())) {

--- a/src/main/java/io/github/ocularminds/blazra/model/ImageReference.java
+++ b/src/main/java/io/github/ocularminds/blazra/model/ImageReference.java
@@ -5,16 +5,35 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-public record ImageReference(String sourceRepository, String dockerHubRepository, String tag) {
-    private static final Pattern COMPONENT = Pattern.compile("[a-z0-9]+(?:[._-][a-z0-9]+)*");
+public record ImageReference(
+        String sourceRepository,
+        RegistryRepository registryRepository,
+        String tag) {
+    private static final Pattern COMPONENT = Pattern.compile(
+            "[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*");
     private static final Pattern TAG = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}");
     private static final Set<String> DOCKER_HUB_HOSTS = Set.of(
             "docker.io",
             "index.docker.io",
             "registry-1.docker.io");
 
+    public ImageReference {
+        if (sourceRepository == null
+                || sourceRepository.isBlank()
+                || sourceRepository.length() > 512
+                || !sourceRepository.equals(sourceRepository.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException("source repository is invalid");
+        }
+        if (registryRepository == null) {
+            throw new IllegalArgumentException("registry repository is required");
+        }
+        if (tag == null || !TAG.matcher(tag).matches()) {
+            throw new IllegalArgumentException("image tag is invalid");
+        }
+    }
+
     public static Optional<ImageReference> parse(String value) {
-        if (value == null || value.isBlank() || value.indexOf('@') >= 0) {
+        if (value == null || value.isBlank() || value.length() > 512 || value.indexOf('@') >= 0) {
             return Optional.empty();
         }
         int lastSlash = value.lastIndexOf('/');
@@ -31,33 +50,31 @@ public record ImageReference(String sourceRepository, String dockerHubRepository
         }
 
         String[] path = sourceRepository.split("/", -1);
-        int offset = 0;
+        RegistryRepository registryRepository;
         if (path.length > 1 && isRegistryHost(path[0])) {
-            if (!DOCKER_HUB_HOSTS.contains(path[0].toLowerCase(Locale.ROOT))) {
+            String host = path[0];
+            String repositoryPath = joinPath(path, 1);
+            if (DOCKER_HUB_HOSTS.contains(host)) {
+                repositoryPath = dockerHubPath(path, 1);
+                if (repositoryPath == null) {
+                    return Optional.empty();
+                }
+                registryRepository = RegistryRepository.dockerHub(repositoryPath);
+            } else {
+                try {
+                    registryRepository = new RegistryRepository(host, repositoryPath);
+                } catch (IllegalArgumentException exception) {
+                    return Optional.empty();
+                }
+            }
+        } else {
+            String repositoryPath = dockerHubPath(path, 0);
+            if (repositoryPath == null) {
                 return Optional.empty();
             }
-            offset = 1;
+            registryRepository = RegistryRepository.dockerHub(repositoryPath);
         }
-
-        int componentCount = path.length - offset;
-        String namespace;
-        String repository;
-        if (componentCount == 1) {
-            namespace = "library";
-            repository = path[offset];
-        } else if (componentCount == 2) {
-            namespace = path[offset];
-            repository = path[offset + 1];
-        } else {
-            return Optional.empty();
-        }
-        if (!COMPONENT.matcher(namespace).matches() || !COMPONENT.matcher(repository).matches()) {
-            return Optional.empty();
-        }
-        return Optional.of(new ImageReference(
-                sourceRepository,
-                namespace + "/" + repository,
-                tag));
+        return Optional.of(new ImageReference(sourceRepository, registryRepository, tag));
     }
 
     public String withTag(String replacement) {
@@ -69,5 +86,29 @@ public record ImageReference(String sourceRepository, String dockerHubRepository
 
     private static boolean isRegistryHost(String value) {
         return value.contains(".") || value.contains(":") || value.equals("localhost");
+    }
+
+    private static String dockerHubPath(String[] path, int offset) {
+        int componentCount = path.length - offset;
+        if (componentCount == 1 && COMPONENT.matcher(path[offset]).matches()) {
+            return "library/" + path[offset];
+        }
+        if (componentCount == 2
+                && COMPONENT.matcher(path[offset]).matches()
+                && COMPONENT.matcher(path[offset + 1]).matches()) {
+            return path[offset] + "/" + path[offset + 1];
+        }
+        return null;
+    }
+
+    private static String joinPath(String[] components, int offset) {
+        StringBuilder joined = new StringBuilder();
+        for (int index = offset; index < components.length; index++) {
+            if (index > offset) {
+                joined.append('/');
+            }
+            joined.append(components[index]);
+        }
+        return joined.toString();
     }
 }

--- a/src/main/java/io/github/ocularminds/blazra/model/RegistryRepository.java
+++ b/src/main/java/io/github/ocularminds/blazra/model/RegistryRepository.java
@@ -1,0 +1,86 @@
+package io.github.ocularminds.blazra.model;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public record RegistryRepository(String host, String path) {
+    public static final String DOCKER_HUB_HOST = "registry-1.docker.io";
+
+    private static final int MAX_HOST_LENGTH = 259;
+    private static final int MAX_PATH_LENGTH = 255;
+    private static final Pattern HOST_NAME = Pattern.compile(
+            "[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"
+                    + "(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*");
+    private static final Pattern PATH_COMPONENT = Pattern.compile(
+            "[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*");
+    private static final Pattern PORT = Pattern.compile("[0-9]{1,5}");
+    private static final Pattern NUMERIC_ADDRESS = Pattern.compile("[0-9]+(?:\\.[0-9]+)+");
+
+    public RegistryRepository {
+        Objects.requireNonNull(host, "registry host is required");
+        Objects.requireNonNull(path, "registry repository path is required");
+        if (host.length() > MAX_HOST_LENGTH
+                || !host.equals(host.toLowerCase(Locale.ROOT))
+                || !validHost(host)) {
+            throw new IllegalArgumentException("registry host is invalid");
+        }
+        if (path.length() > MAX_PATH_LENGTH || !validPath(path)) {
+            throw new IllegalArgumentException("registry repository path is invalid");
+        }
+        if (host.equals(DOCKER_HUB_HOST) && path.split("/", -1).length != 2) {
+            throw new IllegalArgumentException(
+                    "Docker Hub repositories require a namespace and name");
+        }
+    }
+
+    public static RegistryRepository dockerHub(String path) {
+        return new RegistryRepository(DOCKER_HUB_HOST, path);
+    }
+
+    public boolean isDockerHub() {
+        return host.equals(DOCKER_HUB_HOST);
+    }
+
+    private static boolean validHost(String value) {
+        int separator = value.lastIndexOf(':');
+        String hostname = value;
+        if (separator >= 0) {
+            if (separator != value.indexOf(':') || separator == value.length() - 1) {
+                return false;
+            }
+            hostname = value.substring(0, separator);
+            String configuredPort = value.substring(separator + 1);
+            if (!PORT.matcher(configuredPort).matches()) {
+                return false;
+            }
+            try {
+                int port = Integer.parseInt(configuredPort);
+                if (port < 1 || port > 65535) {
+                    return false;
+                }
+            } catch (NumberFormatException exception) {
+                return false;
+            }
+        }
+        return HOST_NAME.matcher(hostname).matches()
+                && hostname.indexOf('.') >= 0
+                && !NUMERIC_ADDRESS.matcher(hostname).matches()
+                && !hostname.endsWith(".local")
+                && !hostname.endsWith(".localhost")
+                && !hostname.endsWith(".internal");
+    }
+
+    private static boolean validPath(String value) {
+        String[] components = value.split("/", -1);
+        if (components.length == 0) {
+            return false;
+        }
+        for (String component : components) {
+            if (!PATH_COMPONENT.matcher(component).matches()) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClient.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClient.java
@@ -16,16 +16,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import io.github.ocularminds.blazra.model.RegistryCredentials;
+import io.github.ocularminds.blazra.model.RegistryRepository;
 
 public final class DockerHubRegistryClient implements RegistryClient {
     private static final URI DEFAULT_BASE_URI = URI.create("https://hub.docker.com/");
     private static final int MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
     private static final int MAX_PAGES = 20;
-    private static final Pattern REPOSITORY = Pattern.compile(
-            "[a-z0-9]+(?:[._-][a-z0-9]+)*/[a-z0-9]+(?:[._-][a-z0-9]+)*");
-
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private final Optional<RegistryCredentials> credentials;
@@ -64,11 +61,11 @@ public final class DockerHubRegistryClient implements RegistryClient {
     }
 
     @Override
-    public List<String> listTags(String repository) throws RegistryException {
-        if (repository == null || !REPOSITORY.matcher(repository).matches()) {
-            throw new IllegalArgumentException("repository must contain a valid namespace and name");
+    public List<String> listTags(RegistryRepository repository) throws RegistryException {
+        if (repository == null || !repository.isDockerHub()) {
+            throw new IllegalArgumentException("a Docker Hub repository is required");
         }
-        String[] components = repository.split("/", 2);
+        String[] components = repository.path().split("/", 2);
         URI page = baseUri.resolve(
                 "v2/namespaces/" + components[0] + "/repositories/" + components[1]
                         + "/tags?page_size=100");

--- a/src/main/java/io/github/ocularminds/blazra/registry/OciBearerChallenge.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/OciBearerChallenge.java
@@ -1,0 +1,136 @@
+package io.github.ocularminds.blazra.registry;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+record OciBearerChallenge(URI realm, String service, String scope) {
+    private static final int MAX_HEADER_LENGTH = 2048;
+    private static final Pattern SERVICE = Pattern.compile("[A-Za-z0-9._:-]{1,255}");
+    private static final Pattern SCOPE = Pattern.compile("[A-Za-z0-9._~:/,-]{1,512}");
+
+    static OciBearerChallenge parse(String header, URI registryBase) throws RegistryException {
+        if (header == null
+                || header.length() > MAX_HEADER_LENGTH
+                || header.length() < 8
+                || !header.regionMatches(true, 0, "Bearer", 0, 6)
+                || !Character.isWhitespace(header.charAt(6))) {
+            throw new RegistryException("OCI registry returned an invalid authentication challenge");
+        }
+
+        Map<String, String> parameters = parseParameters(header, 7);
+        URI realm = parseRealm(parameters.get("realm"), registryBase);
+        String service = parameters.get("service");
+        String scope = parameters.get("scope");
+        if (service == null
+                || scope == null
+                || !SERVICE.matcher(service).matches()
+                || !SCOPE.matcher(scope).matches()) {
+            throw new RegistryException("OCI registry returned an invalid authentication challenge");
+        }
+        return new OciBearerChallenge(realm, service, scope);
+    }
+
+    URI tokenUri() {
+        String separator = realm.getRawQuery() == null ? "?" : "&";
+        return URI.create(realm.toASCIIString()
+                + separator
+                + "service=" + encode(service)
+                + "&scope=" + encode(scope));
+    }
+
+    private static Map<String, String> parseParameters(String header, int start)
+            throws RegistryException {
+        Map<String, String> parameters = new HashMap<>();
+        int index = start;
+        while (index < header.length()) {
+            index = skipWhitespace(header, index);
+            int keyStart = index;
+            while (index < header.length() && validKeyCharacter(header.charAt(index))) {
+                index++;
+            }
+            if (keyStart == index || index >= header.length() || header.charAt(index) != '=') {
+                throw invalidChallenge();
+            }
+            String key = header.substring(keyStart, index).toLowerCase(Locale.ROOT);
+            index++;
+            if (index >= header.length() || header.charAt(index) != '"') {
+                throw invalidChallenge();
+            }
+            StringBuilder value = new StringBuilder();
+            index++;
+            boolean closed = false;
+            while (index < header.length()) {
+                char character = header.charAt(index++);
+                if (character == '"') {
+                    closed = true;
+                    break;
+                }
+                if (character == '\\') {
+                    if (index >= header.length()) {
+                        throw invalidChallenge();
+                    }
+                    character = header.charAt(index++);
+                }
+                if (Character.isISOControl(character)) {
+                    throw invalidChallenge();
+                }
+                value.append(character);
+            }
+            if (!closed || parameters.putIfAbsent(key, value.toString()) != null) {
+                throw invalidChallenge();
+            }
+            index = skipWhitespace(header, index);
+            if (index < header.length()) {
+                if (header.charAt(index) != ',') {
+                    throw invalidChallenge();
+                }
+                index++;
+                if (skipWhitespace(header, index) >= header.length()) {
+                    throw invalidChallenge();
+                }
+            }
+        }
+        return parameters;
+    }
+
+    private static URI parseRealm(String value, URI registryBase) throws RegistryException {
+        try {
+            URI realm = URI.create(value == null ? "" : value);
+            if (!realm.isAbsolute()
+                    || realm.getHost() == null
+                    || realm.getUserInfo() != null
+                    || realm.getFragment() != null
+                    || !realm.getScheme().equalsIgnoreCase(registryBase.getScheme())
+                    || !realm.getAuthority().equalsIgnoreCase(registryBase.getAuthority())) {
+                throw invalidChallenge();
+            }
+            return realm;
+        } catch (IllegalArgumentException exception) {
+            throw invalidChallenge();
+        }
+    }
+
+    private static int skipWhitespace(String value, int index) {
+        while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private static boolean validKeyCharacter(char value) {
+        return Character.isLetterOrDigit(value) || value == '_' || value == '-';
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static RegistryException invalidChallenge() {
+        return new RegistryException("OCI registry returned an invalid authentication challenge");
+    }
+}

--- a/src/main/java/io/github/ocularminds/blazra/registry/OciRegistryClient.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/OciRegistryClient.java
@@ -1,0 +1,244 @@
+package io.github.ocularminds.blazra.registry;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+
+public final class OciRegistryClient implements RegistryClient {
+    private static final int MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+    private static final int MAX_PAGES = 20;
+    private static final int PAGE_SIZE = 100;
+    private static final int MAX_TAGS_PER_PAGE = 1000;
+    private static final int MAX_LINK_HEADER_LENGTH = 2048;
+    private static final Pattern NEXT_LINK = Pattern.compile(
+            "<([^<>]+)>\\s*;[^,]*?\\brel\\s*=\\s*\"?next\"?",
+            Pattern.CASE_INSENSITIVE);
+    private static final int MAX_TOKEN_LENGTH = 16 * 1024;
+    private static final Pattern BEARER_TOKEN = Pattern.compile("[A-Za-z0-9\\-._~+/]+=*");
+    private static final Pattern TAG = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}");
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final Function<RegistryRepository, URI> endpointResolver;
+    private final Duration requestTimeout;
+
+    public OciRegistryClient(Duration connectTimeout, Duration requestTimeout) {
+        this(
+                HttpClient.newBuilder()
+                        .connectTimeout(connectTimeout)
+                        .followRedirects(HttpClient.Redirect.NEVER)
+                        .build(),
+                new ObjectMapper(),
+                repository -> URI.create("https://" + repository.host() + "/"),
+                requestTimeout);
+    }
+
+    OciRegistryClient(
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            Function<RegistryRepository, URI> endpointResolver,
+            Duration requestTimeout) {
+        this.httpClient = Objects.requireNonNull(httpClient, "http client is required");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "object mapper is required");
+        this.endpointResolver = Objects.requireNonNull(
+                endpointResolver,
+                "endpoint resolver is required");
+        this.requestTimeout = Objects.requireNonNull(requestTimeout, "request timeout is required");
+        if (requestTimeout.isZero() || requestTimeout.isNegative()) {
+            throw new IllegalArgumentException("request timeout must be positive");
+        }
+    }
+
+    @Override
+    public List<String> listTags(RegistryRepository repository) throws RegistryException {
+        Objects.requireNonNull(repository, "registry repository is required");
+        URI baseUri = requireHttpBase(endpointResolver.apply(repository));
+        URI page = baseUri.resolve(
+                "v2/" + repository.path() + "/tags/list?n=" + PAGE_SIZE);
+        String bearerToken = null;
+        List<String> tags = new ArrayList<>();
+
+        for (int pageNumber = 0; page != null && pageNumber < MAX_PAGES; pageNumber++) {
+            HttpResponse<InputStream> response = sendTagRequest(page, bearerToken);
+            if (response.statusCode() == 401 && bearerToken == null) {
+                String challengeHeader = response.headers()
+                        .firstValue("WWW-Authenticate")
+                        .orElse(null);
+                close(response.body());
+                OciBearerChallenge challenge = OciBearerChallenge.parse(
+                        challengeHeader,
+                        baseUri);
+                bearerToken = requestToken(challenge);
+                response = sendTagRequest(page, bearerToken);
+            }
+
+            String linkHeader = response.headers().firstValue("Link").orElse(null);
+            JsonNode document = readJson(response, "list OCI registry tags");
+            appendTags(document, repository, tags);
+            page = nextPage(linkHeader, baseUri, repository);
+        }
+        if (page != null) {
+            throw new RegistryException("OCI registry tag response exceeded the page limit");
+        }
+        return List.copyOf(tags);
+    }
+
+    private String requestToken(OciBearerChallenge challenge) throws RegistryException {
+        HttpRequest request = HttpRequest.newBuilder(challenge.tokenUri())
+                .timeout(requestTimeout)
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        JsonNode document = readJson(send(request, "request OCI registry token"),
+                "request OCI registry token");
+        if (document == null || !document.isObject()) {
+            throw new RegistryException("OCI registry returned an invalid authentication token");
+        }
+        String token = text(document.get("token"));
+        String accessToken = text(document.get("access_token"));
+        if (token != null && accessToken != null && !token.equals(accessToken)) {
+            throw new RegistryException("OCI registry returned conflicting authentication tokens");
+        }
+        String selected = token == null ? accessToken : token;
+        if (selected == null
+                || selected.length() > MAX_TOKEN_LENGTH
+                || !BEARER_TOKEN.matcher(selected).matches()) {
+            throw new RegistryException("OCI registry returned an invalid authentication token");
+        }
+        return selected;
+    }
+
+    private HttpResponse<InputStream> sendTagRequest(URI page, String bearerToken)
+            throws RegistryException {
+        HttpRequest.Builder builder = HttpRequest.newBuilder(page)
+                .timeout(requestTimeout)
+                .header("Accept", "application/json")
+                .GET();
+        if (bearerToken != null) {
+            builder.header("Authorization", "Bearer " + bearerToken);
+        }
+        return send(builder.build(), "list OCI registry tags");
+    }
+
+    private HttpResponse<InputStream> send(HttpRequest request, String operation)
+            throws RegistryException {
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RegistryException(operation + " was interrupted", exception);
+        } catch (IOException exception) {
+            throw new RegistryException(operation + " failed", exception);
+        }
+    }
+
+    private JsonNode readJson(HttpResponse<InputStream> response, String operation)
+            throws RegistryException {
+        try (InputStream input = response.body()) {
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new RegistryException(operation + " failed with HTTP " + response.statusCode());
+            }
+            byte[] body = input.readNBytes(MAX_RESPONSE_BYTES + 1);
+            if (body.length > MAX_RESPONSE_BYTES) {
+                throw new RegistryException(operation + " returned too much data");
+            }
+            return objectMapper.readTree(body);
+        } catch (IOException exception) {
+            throw new RegistryException(operation + " returned invalid JSON", exception);
+        }
+    }
+
+    private static void appendTags(
+            JsonNode document,
+            RegistryRepository repository,
+            List<String> tags) throws RegistryException {
+        if (document == null || !document.isObject()) {
+            throw new RegistryException("OCI registry returned an invalid tag response");
+        }
+        JsonNode name = document.get("name");
+        JsonNode foundTags = document.get("tags");
+        if (name == null || !name.isTextual() || !name.textValue().equals(repository.path())) {
+            throw new RegistryException("OCI registry returned an invalid repository name");
+        }
+        if (foundTags == null || foundTags.isNull()) {
+            return;
+        }
+        if (!foundTags.isArray()) {
+            throw new RegistryException("OCI registry returned an invalid tag response");
+        }
+        if (foundTags.size() > MAX_TAGS_PER_PAGE) {
+            throw new RegistryException("OCI registry returned too many tags in one page");
+        }
+        for (JsonNode tag : foundTags) {
+            if (!tag.isTextual() || !TAG.matcher(tag.textValue()).matches()) {
+                throw new RegistryException("OCI registry returned an invalid tag response");
+            }
+            tags.add(tag.textValue());
+        }
+    }
+
+    private static URI nextPage(
+            String linkHeader,
+            URI baseUri,
+            RegistryRepository repository) throws RegistryException {
+        if (linkHeader == null) {
+            return null;
+        }
+        if (linkHeader.length() > MAX_LINK_HEADER_LENGTH) {
+            throw new RegistryException("OCI registry returned an invalid pagination link");
+        }
+        Matcher matcher = NEXT_LINK.matcher(linkHeader);
+        if (!matcher.find()) {
+            throw new RegistryException("OCI registry returned an invalid pagination link");
+        }
+        URI candidate = baseUri.resolve(matcher.group(1));
+        String expectedPath = "/v2/" + repository.path() + "/tags/list";
+        if (!candidate.getScheme().equalsIgnoreCase(baseUri.getScheme())
+                || !candidate.getAuthority().equalsIgnoreCase(baseUri.getAuthority())
+                || !expectedPath.equals(candidate.getPath())
+                || candidate.getRawQuery() == null
+                || candidate.getFragment() != null) {
+            throw new RegistryException("OCI registry returned an unsafe pagination link");
+        }
+        return candidate;
+    }
+
+    private static URI requireHttpBase(URI value) {
+        Objects.requireNonNull(value, "registry base URI is required");
+        if (value.getHost() == null
+                || value.getUserInfo() != null
+                || value.getFragment() != null
+                || !(value.getScheme().equalsIgnoreCase("https")
+                || value.getScheme().equalsIgnoreCase("http"))) {
+            throw new IllegalArgumentException("registry base URI must be an absolute HTTP URL");
+        }
+        return value;
+    }
+
+    private static String text(JsonNode value) {
+        return value != null && value.isTextual() && !value.textValue().isBlank()
+                ? value.textValue()
+                : null;
+    }
+
+    private static void close(InputStream input) throws RegistryException {
+        try {
+            input.close();
+        } catch (IOException exception) {
+            throw new RegistryException("could not close OCI registry response", exception);
+        }
+    }
+}

--- a/src/main/java/io/github/ocularminds/blazra/registry/RegistryClient.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/RegistryClient.java
@@ -1,7 +1,8 @@
 package io.github.ocularminds.blazra.registry;
 
 import java.util.List;
+import io.github.ocularminds.blazra.model.RegistryRepository;
 
 public interface RegistryClient {
-    List<String> listTags(String repository) throws RegistryException;
+    List<String> listTags(RegistryRepository repository) throws RegistryException;
 }

--- a/src/main/java/io/github/ocularminds/blazra/registry/RegistryClientRouter.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/RegistryClientRouter.java
@@ -1,0 +1,25 @@
+package io.github.ocularminds.blazra.registry;
+
+import java.util.List;
+import java.util.Objects;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+
+public final class RegistryClientRouter implements RegistryClient {
+    private final RegistryClient dockerHubClient;
+    private final RegistryClient ociClient;
+
+    public RegistryClientRouter(RegistryClient dockerHubClient, RegistryClient ociClient) {
+        this.dockerHubClient = Objects.requireNonNull(
+                dockerHubClient,
+                "Docker Hub client is required");
+        this.ociClient = Objects.requireNonNull(ociClient, "OCI client is required");
+    }
+
+    @Override
+    public List<String> listTags(RegistryRepository repository) throws RegistryException {
+        Objects.requireNonNull(repository, "registry repository is required");
+        return repository.isDockerHub()
+                ? dockerHubClient.listTags(repository)
+                : ociClient.listTags(repository);
+    }
+}

--- a/src/main/java/io/github/ocularminds/blazra/service/RegistryImageResolver.java
+++ b/src/main/java/io/github/ocularminds/blazra/service/RegistryImageResolver.java
@@ -8,11 +8,11 @@ import io.github.ocularminds.blazra.model.VersionTag;
 import io.github.ocularminds.blazra.registry.RegistryClient;
 import io.github.ocularminds.blazra.registry.RegistryException;
 
-public final class DockerHubImageResolver implements ImageResolver {
+public final class RegistryImageResolver implements ImageResolver {
     private final RegistryClient registryClient;
     private final UpdatePolicy updatePolicy;
 
-    public DockerHubImageResolver(RegistryClient registryClient, UpdatePolicy updatePolicy) {
+    public RegistryImageResolver(RegistryClient registryClient, UpdatePolicy updatePolicy) {
         this.registryClient = Objects.requireNonNull(registryClient, "registry client is required");
         this.updatePolicy = Objects.requireNonNull(updatePolicy, "update policy is required");
     }
@@ -27,7 +27,7 @@ public final class DockerHubImageResolver implements ImageResolver {
         if (currentTag.isEmpty()) {
             return Optional.empty();
         }
-        return registryClient.listTags(reference.get().dockerHubRepository()).stream()
+        return registryClient.listTags(reference.get().registryRepository()).stream()
                 .map(VersionTag::parse)
                 .flatMap(Optional::stream)
                 .filter(candidate -> candidate.compareTo(currentTag.get()) > 0)

--- a/src/test/java/io/github/ocularminds/blazra/model/ImageReferenceTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/model/ImageReferenceTest.java
@@ -10,10 +10,64 @@ import org.junit.jupiter.api.Test;
 class ImageReferenceTest {
     @Test
     void parsesDockerHubReferencesWithoutBreakingRegistryPorts() {
-        assertReference("nginx:1.25", "nginx", "library/nginx", "1.25");
-        assertReference("example/api:v1.2.3", "example/api", "example/api", "v1.2.3");
-        assertReference("docker.io/library/alpine:3.20", "docker.io/library/alpine", "library/alpine", "3.20");
-        assertReference("registry-1.docker.io/team/app:01.04", "registry-1.docker.io/team/app", "team/app", "01.04");
+        assertReference(
+                "nginx:1.25",
+                "nginx",
+                RegistryRepository.DOCKER_HUB_HOST,
+                "library/nginx",
+                "1.25");
+        assertReference(
+                "example/api:v1.2.3",
+                "example/api",
+                RegistryRepository.DOCKER_HUB_HOST,
+                "example/api",
+                "v1.2.3");
+        assertReference(
+                "docker.io/library/alpine:3.20",
+                "docker.io/library/alpine",
+                RegistryRepository.DOCKER_HUB_HOST,
+                "library/alpine",
+                "3.20");
+        assertReference(
+                "registry-1.docker.io/team/app:01.04",
+                "registry-1.docker.io/team/app",
+                RegistryRepository.DOCKER_HUB_HOST,
+                "team/app",
+                "01.04");
+    }
+
+    @Test
+    void parsesPublicOciRegistryReferencesAndNestedPaths() {
+        assertReference(
+                "ghcr.io/team/app:1.2",
+                "ghcr.io/team/app",
+                "ghcr.io",
+                "team/app",
+                "1.2");
+        assertReference(
+                "europe-west1-docker.pkg.dev/project/repository/app:v2.0",
+                "europe-west1-docker.pkg.dev/project/repository/app",
+                "europe-west1-docker.pkg.dev",
+                "project/repository/app",
+                "v2.0");
+        assertReference(
+                "public.ecr.aws/alias/team/app:3.4.5",
+                "public.ecr.aws/alias/team/app",
+                "public.ecr.aws",
+                "alias/team/app",
+                "3.4.5");
+        assertReference(
+                "registry.example:5000/team/app:1.2",
+                "registry.example:5000/team/app",
+                "registry.example:5000",
+                "team/app",
+                "1.2");
+        assertReference(
+                "ghcr.io/team/my--app:1.2",
+                "ghcr.io/team/my--app",
+                "ghcr.io",
+                "team/my--app",
+                "1.2");
     }
 
     @Test
@@ -24,12 +78,18 @@ class ImageReferenceTest {
                 "nginx",
                 "nginx:",
                 "nginx@sha256:1234",
-                "ghcr.io/team/app:1.2",
-                "localhost:5000/team/app:1.2",
                 "docker.io/team/nested/app:1.2",
                 "Docker.IO/team/app:1.2",
+                "registry.example:0/team/app:1.2",
+                "registry.example:65536/team/app:1.2",
+                "registry_example/team/app:1.2",
+                "localhost:5000/team/app:1.2",
+                "127.0.0.1:5000/team/app:1.2",
+                "registry.internal/team/app:1.2",
+                "ghcr.io/team//app:1.2",
                 "team/Bad_Name:1.2",
-                "team/app:bad tag"
+                "team/app:bad tag",
+                "a".repeat(513)
         }) {
             assertTrue(ImageReference.parse(candidate).isEmpty(), () -> "accepted " + candidate);
         }
@@ -40,17 +100,28 @@ class ImageReferenceTest {
         ImageReference reference = ImageReference.parse("docker.io/team/app:1.2").orElseThrow();
         assertEquals("docker.io/team/app:2.0", reference.withTag("2.0"));
         assertThrows(IllegalArgumentException.class, () -> reference.withTag("bad tag"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ImageReference("Bad", reference.registryRepository(), "1.2"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ImageReference("team/app", null, "1.2"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ImageReference("team/app", reference.registryRepository(), "bad tag"));
     }
 
     private static void assertReference(
             String source,
             String sourceRepository,
-            String dockerHubRepository,
+            String registryHost,
+            String registryPath,
             String tag) {
         Optional<ImageReference> parsed = ImageReference.parse(source);
         assertTrue(parsed.isPresent());
         assertEquals(sourceRepository, parsed.get().sourceRepository());
-        assertEquals(dockerHubRepository, parsed.get().dockerHubRepository());
+        assertEquals(registryHost, parsed.get().registryRepository().host());
+        assertEquals(registryPath, parsed.get().registryRepository().path());
         assertEquals(tag, parsed.get().tag());
     }
 }

--- a/src/test/java/io/github/ocularminds/blazra/model/RegistryRepositoryTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/model/RegistryRepositoryTest.java
@@ -1,0 +1,82 @@
+package io.github.ocularminds.blazra.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RegistryRepositoryTest {
+    @Test
+    void validatesDockerHubAndOciRepositories() {
+        RegistryRepository dockerHub = RegistryRepository.dockerHub("library/nginx");
+        RegistryRepository oci = new RegistryRepository(
+                "registry.example.com:5443",
+                "division/team/app");
+
+        assertEquals(RegistryRepository.DOCKER_HUB_HOST, dockerHub.host());
+        assertEquals("library/nginx", dockerHub.path());
+        assertTrue(dockerHub.isDockerHub());
+        assertFalse(oci.isDockerHub());
+        assertEquals(
+                "team/my--app",
+                new RegistryRepository("registry.example", "team/my--app").path());
+    }
+
+    @Test
+    void rejectsInvalidHosts() {
+        assertThrows(NullPointerException.class, () -> new RegistryRepository(null, "team/app"));
+        for (String host : new String[]{
+                "",
+                "Registry.example",
+                "registry_example",
+                "-registry.example",
+                "registry-.example",
+                "registry..example",
+                "registry.example:",
+                "registry.example:0",
+                "registry.example:65536",
+                "registry.example:abc",
+                "registry.example:+1",
+                "registry:5000",
+                "localhost:5000",
+                "127.0.0.1:5000",
+                "127.1:5000",
+                "registry.cluster.local",
+                "registry.service.internal",
+                "[::1]:5000",
+                "a".repeat(260)
+        }) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new RegistryRepository(host, "team/app"),
+                    () -> "accepted host " + host);
+        }
+    }
+
+    @Test
+    void rejectsInvalidPathsAndDockerHubNesting() {
+        assertThrows(NullPointerException.class, () -> new RegistryRepository("ghcr.io", null));
+        for (String path : new String[]{
+                "",
+                "/team/app",
+                "team/app/",
+                "team//app",
+                "team/Bad",
+                "team/bad_name-",
+                "a".repeat(256)
+        }) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new RegistryRepository("ghcr.io", path),
+                    () -> "accepted path " + path);
+        }
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> RegistryRepository.dockerHub("nginx"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> RegistryRepository.dockerHub("team/nested/app"));
+    }
+}

--- a/src/test/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClientTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClientTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import io.github.ocularminds.blazra.model.RegistryCredentials;
+import io.github.ocularminds.blazra.model.RegistryRepository;
 import org.mockito.Mockito;
 
 class DockerHubRegistryClientTest {
@@ -51,7 +52,9 @@ class DockerHubRegistryClientTest {
             }
         });
 
-        assertEquals(List.of("1.0", "1.2"), client(Optional.empty()).listTags("library/nginx"));
+        assertEquals(
+                List.of("1.0", "1.2"),
+                client(Optional.empty()).listTags(repository("library/nginx")));
     }
 
     @Test
@@ -71,7 +74,7 @@ class DockerHubRegistryClientTest {
         Optional<RegistryCredentials> credentials = Optional.of(
                 new RegistryCredentials("robot", "private-token"));
 
-        client(credentials).listTags("team/app");
+        client(credentials).listTags(repository("team/app"));
 
         assertTrue(authenticationBody.get().contains("robot"));
         assertTrue(authenticationBody.get().contains("private-token"));
@@ -85,7 +88,7 @@ class DockerHubRegistryClientTest {
 
         RegistryException exception = assertThrows(
                 RegistryException.class,
-                () -> client(Optional.empty()).listTags("team/app"));
+                () -> client(Optional.empty()).listTags(repository("team/app")));
 
         assertTrue(exception.getMessage().contains("HTTP 500"));
         assertTrue(!exception.getMessage().contains("sensitive"));
@@ -101,9 +104,15 @@ class DockerHubRegistryClientTest {
                 respond(exchange, 200, "{\"next\":\"https://attacker.example/tags\",\"results\":[]}"));
 
         DockerHubRegistryClient client = client(Optional.empty());
-        assertThrows(RegistryException.class, () -> client.listTags("team/bad-json"));
-        assertThrows(RegistryException.class, () -> client.listTags("team/bad-results"));
-        assertThrows(RegistryException.class, () -> client.listTags("team/unsafe-next"));
+        assertThrows(
+                RegistryException.class,
+                () -> client.listTags(repository("team/bad-json")));
+        assertThrows(
+                RegistryException.class,
+                () -> client.listTags(repository("team/bad-results")));
+        assertThrows(
+                RegistryException.class,
+                () -> client.listTags(repository("team/unsafe-next")));
     }
 
     @Test
@@ -111,10 +120,15 @@ class DockerHubRegistryClientTest {
         server.createContext("/v2/auth/token", exchange -> respond(exchange, 200, "{}"));
         DockerHubRegistryClient authenticated = client(Optional.of(
                 new RegistryCredentials("robot", "token")));
-        assertThrows(RegistryException.class, () -> authenticated.listTags("team/app"));
+        assertThrows(
+                RegistryException.class,
+                () -> authenticated.listTags(repository("team/app")));
 
         DockerHubRegistryClient anonymous = client(Optional.empty());
-        assertThrows(IllegalArgumentException.class, () -> anonymous.listTags("invalid"));
+        assertThrows(IllegalArgumentException.class, () -> anonymous.listTags(null));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> anonymous.listTags(new RegistryRepository("ghcr.io", "team/app")));
         assertThrows(
                 IllegalArgumentException.class,
                 () -> new DockerHubRegistryClient(
@@ -136,7 +150,9 @@ class DockerHubRegistryClientTest {
                 Optional.empty(),
                 Duration.ofSeconds(1),
                 Duration.ofSeconds(1));
-        assertThrows(IllegalArgumentException.class, () -> productionClient.listTags("invalid"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> productionClient.listTags(new RegistryRepository("ghcr.io", "team/app")));
     }
 
     @Test
@@ -151,9 +167,15 @@ class DockerHubRegistryClientTest {
                         + "v2/namespaces/team/repositories/endless/tags\",\"results\":[]}"));
 
         DockerHubRegistryClient client = client(Optional.empty());
-        assertThrows(RegistryException.class, () -> client.listTags("team/oversized"));
-        assertThrows(RegistryException.class, () -> client.listTags("team/blank-next"));
-        assertThrows(RegistryException.class, () -> client.listTags("team/endless"));
+        assertThrows(
+                RegistryException.class,
+                () -> client.listTags(repository("team/oversized")));
+        assertThrows(
+                RegistryException.class,
+                () -> client.listTags(repository("team/blank-next")));
+        assertThrows(
+                RegistryException.class,
+                () -> client.listTags(repository("team/endless")));
     }
 
     @Test
@@ -170,7 +192,7 @@ class DockerHubRegistryClientTest {
                 baseUri,
                 Duration.ofSeconds(1));
 
-        assertThrows(RegistryException.class, () -> client.listTags("team/app"));
+        assertThrows(RegistryException.class, () -> client.listTags(repository("team/app")));
     }
 
     @Test
@@ -179,7 +201,9 @@ class DockerHubRegistryClientTest {
                 respond(exchange, 200, "{\"next\":null,\"results\":[]}"));
         Thread.currentThread().interrupt();
         try {
-            assertThrows(RegistryException.class, () -> client(Optional.empty()).listTags("team/app"));
+            assertThrows(
+                    RegistryException.class,
+                    () -> client(Optional.empty()).listTags(repository("team/app")));
             assertTrue(Thread.currentThread().isInterrupted());
         } finally {
             Thread.interrupted();
@@ -193,6 +217,10 @@ class DockerHubRegistryClientTest {
                 credentials,
                 baseUri,
                 Duration.ofSeconds(2));
+    }
+
+    private static RegistryRepository repository(String path) {
+        return RegistryRepository.dockerHub(path);
     }
 
     private static void respond(HttpExchange exchange, int status, String body) throws IOException {

--- a/src/test/java/io/github/ocularminds/blazra/registry/OciBearerChallengeTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/OciBearerChallengeTest.java
@@ -1,0 +1,93 @@
+package io.github.ocularminds.blazra.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class OciBearerChallengeTest {
+    private static final URI REGISTRY = URI.create("https://registry.example.com/");
+
+    @Test
+    void parsesAndEncodesAValidBearerChallenge() throws Exception {
+        OciBearerChallenge challenge = OciBearerChallenge.parse(
+                "Bearer realm=\"https://registry.example.com/token?account=anonymous\","
+                        + "service=\"registry.example.com\","
+                        + "scope=\"repository:team/app:pull\",error=\"ignored\"",
+                REGISTRY);
+
+        assertEquals(URI.create("https://registry.example.com/token?account=anonymous"),
+                challenge.realm());
+        assertEquals("registry.example.com", challenge.service());
+        assertEquals("repository:team/app:pull", challenge.scope());
+        assertEquals(
+                URI.create("https://registry.example.com/token?account=anonymous"
+                        + "&service=registry.example.com"
+                        + "&scope=repository%3Ateam%2Fapp%3Apull"),
+                challenge.tokenUri());
+    }
+
+    @Test
+    void acceptsCaseInsensitiveSchemeAndEscapedValues() throws Exception {
+        OciBearerChallenge challenge = OciBearerChallenge.parse(
+                "bEaReR realm=\"https://registry.example.com/token\", "
+                        + "service=\"registry.example.com\", scope=\"aws\", note=\"a\\\"b\"",
+                REGISTRY);
+
+        assertEquals("aws", challenge.scope());
+    }
+
+    @Test
+    void rejectsMalformedAuthenticationChallenges() {
+        String validRealm = "realm=\"https://registry.example.com/token\"";
+        String validService = "service=\"registry.example.com\"";
+        String validScope = "scope=\"repository:team/app:pull\"";
+        for (String header : new String[]{
+                null,
+                "Basic " + validRealm,
+                "Bearer" + validRealm,
+                "Bearer =\"bad\"," + validService + "," + validScope,
+                "Bearer realm\"bad\"," + validService + "," + validScope,
+                "Bearer realm=bad," + validService + "," + validScope,
+                "Bearer realm=\"unterminated," + validService + "," + validScope,
+                "Bearer realm=\"bad\\",
+                "Bearer realm=\"bad\u0001\"," + validService + "," + validScope,
+                "Bearer " + validRealm + " " + validService + "," + validScope,
+                "Bearer " + validRealm + "," + validRealm + "," + validScope,
+                "Bearer " + validRealm + "," + validService,
+                "Bearer " + validRealm + "," + validScope,
+                "Bearer " + validRealm + ",service=\"bad service\"," + validScope,
+                "Bearer " + validRealm + "," + validService + ",scope=\"bad scope\"",
+                "Bearer " + validRealm + "," + validService + ",scope=\"\"",
+                "Bearer " + validRealm + "," + validService + "," + validScope + ","
+        }) {
+            assertThrows(
+                    RegistryException.class,
+                    () -> OciBearerChallenge.parse(header, REGISTRY),
+                    () -> "accepted challenge " + header);
+        }
+        assertThrows(
+                RegistryException.class,
+                () -> OciBearerChallenge.parse("Bearer " + "x".repeat(2049), REGISTRY));
+    }
+
+    @Test
+    void rejectsUnsafeAuthenticationRealms() {
+        for (String realm : new String[]{
+                "/token",
+                "http://registry.example.com/token",
+                "https://attacker.example/token",
+                "https://user@registry.example.com/token",
+                "https://registry.example.com/token#fragment",
+                "not a URI"
+        }) {
+            String header = "Bearer realm=\"" + realm
+                    + "\",service=\"registry.example.com\",scope=\"aws\"";
+            assertThrows(
+                    RegistryException.class,
+                    () -> OciBearerChallenge.parse(header, REGISTRY),
+                    () -> "accepted realm " + realm);
+        }
+    }
+}

--- a/src/test/java/io/github/ocularminds/blazra/registry/OciRegistryClientTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/OciRegistryClientTest.java
@@ -1,0 +1,308 @@
+package io.github.ocularminds.blazra.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+
+class OciRegistryClientTest {
+    private HttpServer server;
+    private URI baseUri;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/");
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void listsAllAnonymousTagPages() throws Exception {
+        AtomicReference<String> accept = new AtomicReference<>();
+        server.createContext("/v2/team/app/tags/list", exchange -> {
+            accept.set(exchange.getRequestHeaders().getFirst("Accept"));
+            if (exchange.getRequestURI().getQuery().contains("last=1.0")) {
+                respond(exchange, 200, "{\"name\":\"team/app\",\"tags\":[\"1.2\"]}");
+            } else {
+                exchange.getResponseHeaders().set(
+                        "Link",
+                        "</v2/team/app/tags/list?n=100&last=1.0>; rel=\"next\"");
+                respond(exchange, 200, "{\"name\":\"team/app\",\"tags\":[\"1.0\"]}");
+            }
+        });
+
+        assertEquals(List.of("1.0", "1.2"), client().listTags(repository("team/app")));
+        assertEquals("application/json", accept.get());
+    }
+
+    @Test
+    void obtainsAndUsesAnAnonymousBearerToken() throws Exception {
+        AtomicInteger tagRequests = new AtomicInteger();
+        AtomicReference<String> tokenQuery = new AtomicReference<>();
+        server.createContext("/token", exchange -> {
+            tokenQuery.set(exchange.getRequestURI().getQuery());
+            respond(exchange, 200, "{\"access_token\":\"short-lived-token\"}");
+        });
+        server.createContext("/v2/team/app/tags/list", exchange -> {
+            tagRequests.incrementAndGet();
+            String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+            if (authorization == null) {
+                exchange.getResponseHeaders().set(
+                        "WWW-Authenticate",
+                        "Bearer realm=\"" + baseUri + "token\","
+                                + "service=\"registry.example\","
+                                + "scope=\"repository:team/app:pull\"");
+                respond(exchange, 401, "{\"errors\":[]}");
+            } else {
+                assertEquals("Bearer short-lived-token", authorization);
+                respond(exchange, 200, "{\"name\":\"team/app\",\"tags\":null}");
+            }
+        });
+
+        assertEquals(List.of(), client().listTags(repository("team/app")));
+        assertEquals(2, tagRequests.get());
+        assertTrue(tokenQuery.get().contains("service=registry.example"));
+        assertTrue(tokenQuery.get().contains("scope=repository:team/app:pull"));
+    }
+
+    @Test
+    void supportsEcrStyleScopesAndTokenFields() throws Exception {
+        server.createContext("/token/", exchange -> {
+            assertTrue(exchange.getRequestURI().getQuery().contains("scope=aws"));
+            respond(exchange, 200, "{\"token\":\"ecr-token\"}");
+        });
+        authenticatedTags("public/app", "token/", "aws", "ecr-token");
+
+        assertEquals(
+                List.of("1.0"),
+                client().listTags(repository("public/app")));
+    }
+
+    @Test
+    void rejectsTokenAndAuthenticationFailures() {
+        server.createContext("/token-empty", exchange -> respond(exchange, 200, "{}"));
+        server.createContext("/token-conflict", exchange -> respond(
+                exchange,
+                200,
+                "{\"token\":\"first\",\"access_token\":\"second\"}"));
+        server.createContext("/token-malformed", exchange -> respond(
+                exchange,
+                200,
+                "{\"token\":\"bad token\"}"));
+        server.createContext("/token-empty-body", exchange -> respond(exchange, 200, ""));
+        server.createContext("/token-array", exchange -> respond(exchange, 200, "[]"));
+        server.createContext("/token-large", exchange -> respond(
+                exchange,
+                200,
+                "{\"token\":\"" + "a".repeat(16 * 1024 + 1) + "\"}"));
+        challengeOnly("empty/app", "token-empty");
+        challengeOnly("conflict/app", "token-conflict");
+        challengeOnly("malformed/app", "token-malformed");
+        challengeOnly("empty-body/app", "token-empty-body");
+        challengeOnly("array/app", "token-array");
+        challengeOnly("large/app", "token-large");
+        server.createContext("/v2/missing/app/tags/list", exchange ->
+                respond(exchange, 401, "{}"));
+
+        for (String path : new String[]{
+                "empty/app", "conflict/app", "malformed/app", "empty-body/app", "array/app",
+                "large/app", "missing/app"
+        }) {
+            assertThrows(
+                    RegistryException.class,
+                    () -> client().listTags(repository(path)),
+                    () -> "accepted authentication response for " + path);
+        }
+    }
+
+    @Test
+    void rejectsInvalidOrFailedTagResponsesWithoutLeakingBodies() {
+        server.createContext("/v2/error/app/tags/list", exchange ->
+                respond(exchange, 500, "sensitive upstream details"));
+        server.createContext("/v2/json/app/tags/list", exchange ->
+                respond(exchange, 200, "not-json"));
+        server.createContext("/v2/name/app/tags/list", exchange ->
+                respond(exchange, 200, "{\"name\":\"other/app\",\"tags\":[]}"));
+        server.createContext("/v2/object/app/tags/list", exchange ->
+                respond(exchange, 200, "{\"name\":\"object/app\",\"tags\":{}}"));
+        server.createContext("/v2/element/app/tags/list", exchange ->
+                respond(exchange, 200, "{\"name\":\"element/app\",\"tags\":[1]}"));
+        server.createContext("/v2/tag/app/tags/list", exchange ->
+                respond(exchange, 200, "{\"name\":\"tag/app\",\"tags\":[\"bad tag\"]}"));
+        server.createContext("/v2/empty/app/tags/list", exchange ->
+                respond(exchange, 200, ""));
+
+        RegistryException failure = assertThrows(
+                RegistryException.class,
+                () -> client().listTags(repository("error/app")));
+        assertTrue(failure.getMessage().contains("HTTP 500"));
+        assertTrue(!failure.getMessage().contains("sensitive"));
+        for (String path : new String[]{
+                "json/app", "name/app", "object/app", "element/app", "tag/app", "empty/app"
+        }) {
+            assertThrows(
+                    RegistryException.class,
+                    () -> client().listTags(repository(path)),
+                    () -> "accepted invalid response for " + path);
+        }
+    }
+
+    @Test
+    void boundsResponseSizeAndPagination() {
+        String oversized = "{\"name\":\"large/app\",\"tags\":[]}" + " ".repeat(2 * 1024 * 1024);
+        server.createContext("/v2/large/app/tags/list", exchange ->
+                respond(exchange, 200, oversized));
+        linkedTags("unsafe/app", "<https://attacker.example/tags>; rel=\"next\"");
+        linkedTags("wrong/app", "</v2/other/app/tags/list?n=100>; rel=\"next\"");
+        linkedTags("malformed-link/app", "not-a-link");
+        linkedTags("large-link/app", "<" + "a".repeat(2049) + ">; rel=\"next\"");
+        linkedTags(
+                "endless/app",
+                "</v2/endless/app/tags/list?n=100&last=again>; rel=\"next\"");
+        server.createContext("/v2/many/app/tags/list", exchange -> respond(
+                exchange,
+                200,
+                "{\"name\":\"many/app\",\"tags\":[\"1.0\""
+                        + ",\"1.0\"".repeat(1000) + "]}"));
+
+        for (String path : new String[]{
+                "large/app", "unsafe/app", "wrong/app", "malformed-link/app", "large-link/app",
+                "endless/app", "many/app"
+        }) {
+            assertThrows(
+                    RegistryException.class,
+                    () -> client().listTags(repository(path)),
+                    () -> "accepted unbounded response for " + path);
+        }
+    }
+
+    @Test
+    void validatesConstructionAndPreservesInterruptStatus() {
+        new OciRegistryClient(Duration.ofSeconds(1), Duration.ofSeconds(1));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new OciRegistryClient(Duration.ZERO, Duration.ofSeconds(1)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new OciRegistryClient(
+                        HttpClient.newHttpClient(),
+                        new ObjectMapper(),
+                        ignored -> URI.create("file:///tmp/registry"),
+                        Duration.ofSeconds(1)).listTags(repository("team/app")));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new OciRegistryClient(
+                        HttpClient.newHttpClient(),
+                        new ObjectMapper(),
+                        ignored -> baseUri,
+                        Duration.ZERO));
+        assertThrows(
+                NullPointerException.class,
+                () -> new OciRegistryClient(
+                        null,
+                        new ObjectMapper(),
+                        ignored -> baseUri,
+                        Duration.ofSeconds(1)));
+        assertThrows(
+                NullPointerException.class,
+                () -> new OciRegistryClient(
+                        HttpClient.newHttpClient(),
+                        null,
+                        ignored -> baseUri,
+                        Duration.ofSeconds(1)));
+        assertThrows(
+                NullPointerException.class,
+                () -> new OciRegistryClient(
+                        HttpClient.newHttpClient(),
+                        new ObjectMapper(),
+                        null,
+                        Duration.ofSeconds(1)));
+        assertThrows(NullPointerException.class, () -> client().listTags(null));
+
+        server.createContext("/v2/team/app/tags/list", exchange ->
+                respond(exchange, 200, "{\"name\":\"team/app\",\"tags\":[]}"));
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(
+                    RegistryException.class,
+                    () -> client().listTags(repository("team/app")));
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    private void authenticatedTags(String path, String tokenPath, String scope, String token) {
+        server.createContext("/v2/" + path + "/tags/list", exchange -> {
+            String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+            if (authorization == null) {
+                exchange.getResponseHeaders().set(
+                        "WWW-Authenticate",
+                        "Bearer realm=\"" + baseUri + tokenPath + "\","
+                                + "service=\"registry.example\",scope=\"" + scope + "\"");
+                respond(exchange, 401, "{}");
+            } else {
+                assertEquals("Bearer " + token, authorization);
+                respond(exchange, 200, "{\"name\":\"" + path + "\",\"tags\":[\"1.0\"]}");
+            }
+        });
+    }
+
+    private void challengeOnly(String path, String tokenPath) {
+        server.createContext("/v2/" + path + "/tags/list", exchange -> {
+            exchange.getResponseHeaders().set(
+                    "WWW-Authenticate",
+                    "Bearer realm=\"" + baseUri + tokenPath + "\","
+                            + "service=\"registry.example\",scope=\"aws\"");
+            respond(exchange, 401, "{}");
+        });
+    }
+
+    private void linkedTags(String path, String link) {
+        server.createContext("/v2/" + path + "/tags/list", exchange -> {
+            exchange.getResponseHeaders().set("Link", link);
+            respond(exchange, 200, "{\"name\":\"" + path + "\",\"tags\":[]}");
+        });
+    }
+
+    private OciRegistryClient client() {
+        return new OciRegistryClient(
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build(),
+                new ObjectMapper(),
+                ignored -> baseUri,
+                Duration.ofSeconds(2));
+    }
+
+    private static RegistryRepository repository(String path) {
+        return new RegistryRepository("registry.example", path);
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+}

--- a/src/test/java/io/github/ocularminds/blazra/registry/RegistryClientRouterTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/RegistryClientRouterTest.java
@@ -1,0 +1,44 @@
+package io.github.ocularminds.blazra.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+
+class RegistryClientRouterTest {
+    @Test
+    void isolatesDockerHubFromOtherOciRegistries() throws Exception {
+        AtomicInteger dockerHubCalls = new AtomicInteger();
+        AtomicInteger ociCalls = new AtomicInteger();
+        RegistryClient dockerHub = repository -> {
+            dockerHubCalls.incrementAndGet();
+            return List.of("docker");
+        };
+        RegistryClient oci = repository -> {
+            ociCalls.incrementAndGet();
+            return List.of("oci");
+        };
+        RegistryClientRouter router = new RegistryClientRouter(dockerHub, oci);
+
+        assertEquals(
+                List.of("docker"),
+                router.listTags(RegistryRepository.dockerHub("library/nginx")));
+        assertEquals(
+                List.of("oci"),
+                router.listTags(new RegistryRepository("ghcr.io", "team/app")));
+        assertEquals(1, dockerHubCalls.get());
+        assertEquals(1, ociCalls.get());
+    }
+
+    @Test
+    void rejectsMissingDependenciesAndRepositories() {
+        RegistryClient client = repository -> List.of();
+        assertThrows(NullPointerException.class, () -> new RegistryClientRouter(null, client));
+        assertThrows(NullPointerException.class, () -> new RegistryClientRouter(client, null));
+        RegistryClientRouter router = new RegistryClientRouter(client, client);
+        assertThrows(NullPointerException.class, () -> router.listTags(null));
+    }
+}

--- a/src/test/java/io/github/ocularminds/blazra/service/RegistryImageResolverTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/service/RegistryImageResolverTest.java
@@ -1,38 +1,40 @@
 package io.github.ocularminds.blazra.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import io.github.ocularminds.blazra.model.RegistryRepository;
 import io.github.ocularminds.blazra.registry.RegistryClient;
 
-class DockerHubImageResolverTest {
+class RegistryImageResolverTest {
     @Test
-    void selectsTheHighestNewerNumericTag() throws Exception {
-        AtomicReference<String> requestedRepository = new AtomicReference<>();
+    void selectsTheHighestNewerNumericTagFromTheParsedRegistry() throws Exception {
+        AtomicReference<RegistryRepository> requestedRepository = new AtomicReference<>();
         RegistryClient registry = repository -> {
             requestedRepository.set(repository);
             return List.of("latest", "1.9", "1.10", "2.0.1", "2.0.0-rc1");
         };
-        DockerHubImageResolver resolver = new DockerHubImageResolver(registry, UpdatePolicy.MAJOR);
+        RegistryImageResolver resolver = new RegistryImageResolver(registry, UpdatePolicy.MAJOR);
 
-        Optional<String> latest = resolver.latestImage("team/api:1.8");
+        Optional<String> latest = resolver.latestImage("ghcr.io/team/api:1.8");
 
-        assertEquals(Optional.of("team/api:2.0.1"), latest);
-        assertEquals("team/api", requestedRepository.get());
+        assertEquals(Optional.of("ghcr.io/team/api:2.0.1"), latest);
+        assertEquals(new RegistryRepository("ghcr.io", "team/api"), requestedRepository.get());
     }
 
     @Test
     void preservesCurrentImageWhenNoCompatibleUpgradeExists() throws Exception {
         RegistryClient registry = repository -> List.of("latest", "1.0", "1.2-rc1");
-        DockerHubImageResolver resolver = new DockerHubImageResolver(registry, UpdatePolicy.MAJOR);
+        RegistryImageResolver resolver = new RegistryImageResolver(registry, UpdatePolicy.MAJOR);
 
         assertTrue(resolver.latestImage("team/api:1.2").isEmpty());
         assertTrue(resolver.latestImage("team/api:latest").isEmpty());
-        assertTrue(resolver.latestImage("ghcr.io/team/api:1.2").isEmpty());
+        assertTrue(resolver.latestImage("team/api@sha256:1234").isEmpty());
     }
 
     @Test
@@ -42,26 +44,38 @@ class DockerHubImageResolverTest {
 
         assertEquals(
                 Optional.of("team/api:1.2.4"),
-                new DockerHubImageResolver(registry, UpdatePolicy.PATCH)
+                new RegistryImageResolver(registry, UpdatePolicy.PATCH)
                         .latestImage("team/api:1.2.3"));
         assertEquals(
                 Optional.of("team/api:1.3.0"),
-                new DockerHubImageResolver(registry, UpdatePolicy.MINOR)
+                new RegistryImageResolver(registry, UpdatePolicy.MINOR)
                         .latestImage("team/api:1.2.3"));
         assertEquals(
                 Optional.of("team/api:2.0.0"),
-                new DockerHubImageResolver(registry, UpdatePolicy.MAJOR)
+                new RegistryImageResolver(registry, UpdatePolicy.MAJOR)
                         .latestImage("team/api:1.2.3"));
     }
 
     @Test
     void preservesTheVersionPrefixConvention() throws Exception {
         RegistryClient registry = repository -> List.of("1.2.4", "v1.2.5");
-        DockerHubImageResolver resolver = new DockerHubImageResolver(
+        RegistryImageResolver resolver = new RegistryImageResolver(
                 registry,
                 UpdatePolicy.PATCH);
 
         assertEquals(Optional.of("team/api:v1.2.5"), resolver.latestImage("team/api:v1.2.3"));
         assertEquals(Optional.of("team/api:1.2.4"), resolver.latestImage("team/api:1.2.3"));
+    }
+
+    @Test
+    void rejectsMissingDependencies() {
+        RegistryClient registry = repository -> List.of();
+
+        assertThrows(
+                NullPointerException.class,
+                () -> new RegistryImageResolver(null, UpdatePolicy.PATCH));
+        assertThrows(
+                NullPointerException.class,
+                () -> new RegistryImageResolver(registry, null));
     }
 }


### PR DESCRIPTION
## Summary

- introduce a validated registry repository model and route Docker Hub separately from other OCI registries
- support anonymous OCI Distribution tag discovery for GHCR, ECR Public, and compatible public GAR/ACR repositories
- preserve the dedicated Docker Hub adapter so its credentials can never be sent to another registry
- rename the image resolver around its registry-neutral responsibility and document public OCI configuration

## Security and performance

- require fully qualified public registry hosts and reject localhost, numeric IP, `.local`, and `.internal` destinations
- restrict bearer-token services and pagination to the registry origin, disable redirects, and validate repository/tag responses
- bound response bodies, tokens, link headers, page counts, tags per page, connect time, and request time
- retain non-overlapping polling and the one-sidecar replica guard

## Validation

- `./gradlew clean check --no-daemon`
- JaCoCo: 700/749 lines (93.5%), 406/470 branches (86.4%)
- Helm lint/render tests, including nested ECR Public image references
- release and security-automation contract tests
- ShellCheck and actionlint
- live anonymous bearer/pagination smoke tests against `ghcr.io/ocularminds/blazra` and `public.ecr.aws/amazonlinux/amazonlinux`
- largest Java file: 308 LOC
