### PR TITLE
Support private OCI registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 [![Java 17](https://img.shields.io/badge/Java-17-ED8B00?logo=openjdk&logoColor=white)](https://adoptium.net/)
 
 Blazra watches one container in a Kubernetes Deployment and updates its image
-when a newer numeric tag is available. It supports Docker Hub and anonymous
-public OCI Distribution registries, including GHCR and ECR Public. The Helm
-chart runs Blazra as a Kubernetes-native sidecar beside that workload and
-grants access to exactly one Deployment.
+when a newer numeric tag is available. It supports Docker Hub plus public and
+private OCI Distribution repositories, including GHCR, GAR, ACR, and ECR
+Public. The Helm chart runs Blazra as a Kubernetes-native sidecar beside that
+workload and grants access to exactly one Deployment.
 
 Supported tags contain two to four numeric components, with an optional `v`
-prefix—for example `1.4`, `v2.3.1`, or `3.1.0.12`. Digests, private non-Docker
-Hub registries, and non-numeric release tags are deliberately left unchanged.
-The default `PATCH` policy keeps the first two numeric components fixed;
-`MINOR` keeps the first component fixed, while `MAJOR` permits any newer
-numeric track. Updates also preserve whether the current tag uses a `v` prefix.
+prefix—for example `1.4`, `v2.3.1`, or `3.1.0.12`. Digests and non-numeric
+release tags are deliberately left unchanged. The default `PATCH` policy keeps
+the first two numeric components fixed; `MINOR` keeps the first component
+fixed, while `MAJOR` permits any newer numeric track. Updates also preserve
+whether the current tag uses a `v` prefix.
 
 ## Published artifacts
 
@@ -98,7 +98,7 @@ Use a scoped Docker Hub access token, never an account password. The chart does
 not accept secret values directly, so they cannot be persisted in Helm release
 values.
 
-### Public OCI registries
+### OCI registries
 
 Use a fully qualified repository for public GHCR, Google Artifact Registry,
 Azure Container Registry, Amazon ECR Public, or another OCI Distribution
@@ -113,10 +113,38 @@ workload:
 
 Anonymous registries may issue a short-lived bearer token challenge. Blazra
 accepts that flow only when the token service uses the registry's own HTTPS
-origin. Registry names must be fully qualified public DNS names; literal IP,
-localhost, `.local`, and `.internal` destinations are rejected. Private OCI
-registry credentials are not yet supported; Docker Hub credentials remain
-isolated to Docker Hub requests.
+origin. Registry names must be externally reachable, fully qualified DNS names;
+literal IP, localhost, `.local`, and `.internal` destinations are rejected.
+
+For a private OCI repository, create a standard Kubernetes Docker config
+Secret. Use a read-only account or token with pull access only:
+
+```shell
+kubectl create secret docker-registry private-registry \
+  --namespace apps \
+  --docker-server=ghcr.io \
+  --docker-username=YOUR_ACCOUNT \
+  --docker-password=YOUR_READ_ONLY_TOKEN
+```
+
+Reference the same Secret for the kubelet and the Blazra sidecar:
+
+```yaml
+imagePullSecrets:
+  - name: private-registry
+
+blazra:
+  ociRegistryCredentials:
+    existingSecret: private-registry
+```
+
+The `.dockerconfigjson` file is mounted read-only into Blazra and never into the
+primary workload. Blazra looks up credentials by exact registry host and sends
+them only after that registry returns a Bearer or Basic authentication
+challenge. It rereads the projected file for each new challenge, allowing
+Kubernetes Secret rotation without rebuilding the image. Docker credential
+helpers are not executed; the Secret must contain a static `auth` entry.
+Docker Hub credentials remain isolated to the dedicated Docker Hub client.
 
 ## Important values
 
@@ -131,6 +159,7 @@ isolated to Docker Hub requests.
 | `blazra.updatePolicy` | `PATCH` | Allow `PATCH`, `MINOR`, or `MAJOR` version scope |
 | `blazra.dryRun` | `false` | Report changes without applying them |
 | `blazra.registryCredentials.existingSecret` | empty | Optional Docker Hub Secret |
+| `blazra.ociRegistryCredentials.existingSecret` | empty | Optional Docker config Secret for private OCI repositories |
 | `rbac.create` | `true` | Create the least-privilege Role and binding |
 | `service.enabled` | `true` | Expose the primary workload with a Service |
 
@@ -150,6 +179,8 @@ See [`values.yaml`](charts/blazra/values.yaml) for the complete configuration.
 - Registry responses, pagination, timeouts, bearer tokens, and origins are
   bounded and validated. Error messages do not include upstream bodies or
   credentials, and Docker Hub credentials are never routed to another host.
+- Private OCI credentials are resolved by exact host, mounted only into Blazra,
+  and sent only in response to an HTTPS authentication challenge.
 - Kubernetes writes use the resource version and re-check the current image to
   avoid overwriting concurrent changes.
 - CodeQL scans Java and GitHub Actions on every change and weekly. Dependency
@@ -171,6 +202,7 @@ running the image directly.
 | `BLAZRA_CONNECT_TIMEOUT` | No | `PT5S` | Registry connection timeout |
 | `BLAZRA_REQUEST_TIMEOUT` | No | `PT15S` | Registry request timeout |
 | `BLAZRA_DRY_RUN` | No | `false` | Report updates without writing them |
+| `BLAZRA_OCI_REGISTRY_CONFIG_PATH` | No | — | Absolute path to a Docker `config.json` credential file |
 | `DOCKER_HUB_USERNAME` | No | — | Configure together with the token |
 | `DOCKER_HUB_TOKEN` | No | — | Scoped Docker Hub access token |
 
@@ -185,8 +217,8 @@ the update policy:
 
 - `model` owns validated, immutable domain values.
 - `service` owns image selection and update orchestration.
-- `registry` routes Docker Hub to its dedicated adapter and other public images
-  to a bounded OCI Distribution adapter.
+- `registry` routes Docker Hub to its dedicated adapter and other images to a
+  bounded OCI Distribution adapter with a host-scoped credential provider.
 - `repository` adapts Kubernetes with optimistic concurrency.
 - `runtime` schedules non-overlapping checks.
 - `config` validates all input before startup.

--- a/charts/blazra/templates/deployment.yaml
+++ b/charts/blazra/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
                   name: {{ . | quote }}
                   key: {{ $.Values.blazra.registryCredentials.tokenKey | quote }}
             {{- end }}
+            {{- with .Values.blazra.ociRegistryCredentials.existingSecret }}
+            - name: BLAZRA_OCI_REGISTRY_CONFIG_PATH
+              value: /var/run/secrets/blazra/registry/config.json
+            {{- end }}
           securityContext:
             {{- toYaml .Values.blazra.securityContext | nindent 12 }}
           resources:
@@ -72,6 +76,11 @@ spec:
             - name: kubernetes-api-access
               mountPath: /var/run/secrets/kubernetes.io/serviceaccount
               readOnly: true
+            {{- with .Values.blazra.ociRegistryCredentials.existingSecret }}
+            - name: oci-registry-credentials
+              mountPath: /var/run/secrets/blazra/registry
+              readOnly: true
+            {{- end }}
       containers:
         - name: {{ .Values.workload.containerName }}
           image: {{ include "blazra.workloadImage" . | quote }}
@@ -118,6 +127,15 @@ spec:
                     - path: namespace
                       fieldRef:
                         fieldPath: metadata.namespace
+        {{- with .Values.blazra.ociRegistryCredentials.existingSecret }}
+        - name: oci-registry-credentials
+          secret:
+            secretName: {{ . | quote }}
+            defaultMode: 0444
+            items:
+              - key: {{ $.Values.blazra.ociRegistryCredentials.configKey | quote }}
+                path: config.json
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/blazra/tests/render.sh
+++ b/charts/blazra/tests/render.sh
@@ -58,6 +58,7 @@ mount_count="$(grep -Fc 'mountPath: /var/run/secrets/kubernetes.io/serviceaccoun
 if grep -Fq 'DOCKER_HUB_TOKEN' "${test_dir}/default.yaml"; then
   fail "anonymous installs must not emit credential references"
 fi
+assert_not_contains "${test_dir}/default.yaml" "BLAZRA_OCI_REGISTRY_CONFIG_PATH"
 
 helm template secured "${chart_dir}" \
   --namespace apps \
@@ -75,6 +76,25 @@ assert_contains "${test_dir}/secured.yaml" "name: \"docker-hub\""
 assert_contains "${test_dir}/secured.yaml" "key: \"access-token\""
 assert_contains "${test_dir}/secured.yaml" "value: \"web\""
 assert_not_contains "${test_dir}/secured.yaml" "untrusted"
+
+helm template private-oci "${chart_dir}" \
+  --namespace apps \
+  --kube-version 1.29.0 \
+  --set workload.image.repository=ghcr.io/example/private-app \
+  --set blazra.ociRegistryCredentials.existingSecret=private-registry \
+  --set-string blazra.ociRegistryCredentials.configKey=.dockerconfigjson \
+  --set imagePullSecrets[0].name=private-registry > "${test_dir}/private-oci.yaml"
+
+assert_contains "${test_dir}/private-oci.yaml" "name: BLAZRA_OCI_REGISTRY_CONFIG_PATH"
+assert_contains "${test_dir}/private-oci.yaml" "/var/run/secrets/blazra/registry/config.json"
+assert_contains "${test_dir}/private-oci.yaml" "name: oci-registry-credentials"
+assert_contains "${test_dir}/private-oci.yaml" "secretName: \"private-registry\""
+assert_contains "${test_dir}/private-oci.yaml" "key: \".dockerconfigjson\""
+assert_contains "${test_dir}/private-oci.yaml" "- name: private-registry"
+
+registry_mount_count="$(grep -Fc 'mountPath: /var/run/secrets/blazra/registry' \
+  "${test_dir}/private-oci.yaml")"
+[[ "${registry_mount_count}" == "1" ]] || fail "registry credentials must be mounted only in Blazra"
 
 digest="sha256:$(printf 'a%.0s' {1..64})"
 helm template pinned "${chart_dir}" \
@@ -127,6 +147,13 @@ if helm template invalid-policy "${chart_dir}" \
   --kube-version 1.29.0 \
   --set blazra.updatePolicy=EVERYTHING > /dev/null 2>&1; then
   fail "unknown update policies must be rejected"
+fi
+
+if helm template invalid-registry-key "${chart_dir}" \
+  --kube-version 1.29.0 \
+  --set blazra.ociRegistryCredentials.existingSecret=private-registry \
+  --set blazra.ociRegistryCredentials.configKey=bad/key > /dev/null 2>&1; then
+  fail "invalid Docker config Secret keys must be rejected"
 fi
 
 if helm template missing-service-account "${chart_dir}" \

--- a/charts/blazra/values.schema.json
+++ b/charts/blazra/values.schema.json
@@ -93,6 +93,7 @@
         "requestTimeout",
         "dryRun",
         "registryCredentials",
+        "ociRegistryCredentials",
         "resources",
         "securityContext"
       ],
@@ -131,6 +132,24 @@
             },
             "tokenKey": {
               "$ref": "#/definitions/nonEmptyString"
+            }
+          }
+        },
+        "ociRegistryCredentials": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["existingSecret", "configKey"],
+          "properties": {
+            "existingSecret": {
+              "type": "string",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9](?:[-.a-z0-9]*[a-z0-9])?$"
+            },
+            "configKey": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 253,
+              "pattern": "^[A-Za-z0-9._-]+$"
             }
           }
         },

--- a/charts/blazra/values.yaml
+++ b/charts/blazra/values.yaml
@@ -34,6 +34,9 @@ blazra:
     existingSecret: ""
     usernameKey: username
     tokenKey: token
+  ociRegistryCredentials:
+    existingSecret: ""
+    configKey: .dockerconfigjson
   resources:
     requests:
       cpu: 25m

--- a/src/main/java/io/github/ocularminds/blazra/BlazraApplication.java
+++ b/src/main/java/io/github/ocularminds/blazra/BlazraApplication.java
@@ -9,6 +9,8 @@ import io.github.ocularminds.blazra.registry.DockerHubRegistryClient;
 import io.github.ocularminds.blazra.registry.OciRegistryClient;
 import io.github.ocularminds.blazra.registry.RegistryClient;
 import io.github.ocularminds.blazra.registry.RegistryClientRouter;
+import io.github.ocularminds.blazra.registry.auth.DockerConfigCredentialProvider;
+import io.github.ocularminds.blazra.registry.auth.RegistryCredentialProvider;
 import io.github.ocularminds.blazra.repository.kubernetes.Fabric8DeploymentRepository;
 import io.github.ocularminds.blazra.runtime.PollingRunner;
 import io.github.ocularminds.blazra.service.DeploymentMonitor;
@@ -37,12 +39,18 @@ public final class BlazraApplication {
 
     static void run(BlazraConfig config) throws InterruptedException {
         try (KubernetesClient kubernetesClient = new KubernetesClientBuilder().build()) {
+            RegistryCredentialProvider ociCredentials = config.ociRegistryConfigPath()
+                    .<RegistryCredentialProvider>map(DockerConfigCredentialProvider::new)
+                    .orElseGet(RegistryCredentialProvider::anonymous);
             RegistryClient registryClient = new RegistryClientRouter(
                     new DockerHubRegistryClient(
-                            config.registryCredentials(),
+                            config.dockerHubCredentials(),
                             config.connectTimeout(),
                             config.requestTimeout()),
-                    new OciRegistryClient(config.connectTimeout(), config.requestTimeout()));
+                    new OciRegistryClient(
+                            config.connectTimeout(),
+                            config.requestTimeout(),
+                            ociCredentials));
             DeploymentMonitor monitor = new DeploymentMonitor(
                     new Fabric8DeploymentRepository(kubernetesClient),
                     new RegistryImageResolver(registryClient, config.updatePolicy()),

--- a/src/main/java/io/github/ocularminds/blazra/config/BlazraConfig.java
+++ b/src/main/java/io/github/ocularminds/blazra/config/BlazraConfig.java
@@ -1,5 +1,7 @@
 package io.github.ocularminds.blazra.config;
 
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
@@ -22,7 +24,8 @@ public final class BlazraConfig {
     private final Duration requestTimeout;
     private final boolean dryRun;
     private final UpdatePolicy updatePolicy;
-    private final Optional<RegistryCredentials> registryCredentials;
+    private final Optional<RegistryCredentials> dockerHubCredentials;
+    private final Optional<Path> ociRegistryConfigPath;
 
     public BlazraConfig(
             DeploymentTarget target,
@@ -31,7 +34,8 @@ public final class BlazraConfig {
             Duration requestTimeout,
             boolean dryRun,
             UpdatePolicy updatePolicy,
-            Optional<RegistryCredentials> registryCredentials) {
+            Optional<RegistryCredentials> dockerHubCredentials,
+            Optional<Path> ociRegistryConfigPath) {
         this.target = Objects.requireNonNull(target, "target is required");
         this.pollInterval = requireDuration(
                 pollInterval,
@@ -42,9 +46,12 @@ public final class BlazraConfig {
         this.requestTimeout = requirePositive(requestTimeout, "request timeout");
         this.dryRun = dryRun;
         this.updatePolicy = Objects.requireNonNull(updatePolicy, "update policy is required");
-        this.registryCredentials = Objects.requireNonNull(
-                registryCredentials,
-                "registry credentials are required");
+        this.dockerHubCredentials = Objects.requireNonNull(
+                dockerHubCredentials,
+                "Docker Hub credentials are required");
+        this.ociRegistryConfigPath = Objects.requireNonNull(
+                ociRegistryConfigPath,
+                "OCI registry config path is required");
     }
 
     public static BlazraConfig fromEnvironment() {
@@ -72,7 +79,8 @@ public final class BlazraConfig {
                 DEFAULT_REQUEST_TIMEOUT);
         boolean dryRun = booleanValue(variables, "DRY_RUN", false);
         UpdatePolicy updatePolicy = updatePolicy(variables.value("UPDATE_POLICY").orElse(null));
-        Optional<RegistryCredentials> credentials = credentials(environment);
+        Optional<RegistryCredentials> dockerHubCredentials = dockerHubCredentials(environment);
+        Optional<Path> ociRegistryConfigPath = ociRegistryConfigPath(variables);
         return new BlazraConfig(
                 target,
                 pollInterval,
@@ -80,7 +88,8 @@ public final class BlazraConfig {
                 requestTimeout,
                 dryRun,
                 updatePolicy,
-                credentials);
+                dockerHubCredentials,
+                ociRegistryConfigPath);
     }
 
     public DeploymentTarget target() {
@@ -107,11 +116,16 @@ public final class BlazraConfig {
         return updatePolicy;
     }
 
-    public Optional<RegistryCredentials> registryCredentials() {
-        return registryCredentials;
+    public Optional<RegistryCredentials> dockerHubCredentials() {
+        return dockerHubCredentials;
     }
 
-    private static Optional<RegistryCredentials> credentials(Map<String, String> environment) {
+    public Optional<Path> ociRegistryConfigPath() {
+        return ociRegistryConfigPath;
+    }
+
+    private static Optional<RegistryCredentials> dockerHubCredentials(
+            Map<String, String> environment) {
         String identifier = environment.get("DOCKER_HUB_USERNAME");
         String secret = environment.get("DOCKER_HUB_TOKEN");
         if (isBlank(identifier) && isBlank(secret)) {
@@ -122,6 +136,29 @@ public final class BlazraConfig {
                     "DOCKER_HUB_USERNAME and DOCKER_HUB_TOKEN must be configured together");
         }
         return Optional.of(new RegistryCredentials(identifier, secret));
+    }
+
+    private static Optional<Path> ociRegistryConfigPath(EnvironmentVariables variables) {
+        return variables.value("OCI_REGISTRY_CONFIG_PATH").map(value -> {
+            if (value.length() > 4096) {
+                throw new IllegalArgumentException(
+                        variables.currentName("OCI_REGISTRY_CONFIG_PATH") + " is too long");
+            }
+            try {
+                Path path = Path.of(value);
+                if (!path.isAbsolute()) {
+                    throw new IllegalArgumentException(
+                            variables.currentName("OCI_REGISTRY_CONFIG_PATH")
+                                    + " must be an absolute path");
+                }
+                return path.normalize();
+            } catch (InvalidPathException exception) {
+                throw new IllegalArgumentException(
+                        variables.currentName("OCI_REGISTRY_CONFIG_PATH")
+                                + " must be a valid path",
+                        exception);
+            }
+        });
     }
 
     private static String required(EnvironmentVariables variables, String suffix) {

--- a/src/main/java/io/github/ocularminds/blazra/model/RegistryCredentials.java
+++ b/src/main/java/io/github/ocularminds/blazra/model/RegistryCredentials.java
@@ -1,8 +1,18 @@
 package io.github.ocularminds.blazra.model;
 
 public record RegistryCredentials(String identifier, String secret) {
+    private static final int MAX_IDENTIFIER_LENGTH = 256;
+    private static final int MAX_SECRET_LENGTH = 16 * 1024;
+
     public RegistryCredentials {
-        if (identifier == null || identifier.isBlank() || secret == null || secret.isBlank()) {
+        if (identifier == null
+                || identifier.isBlank()
+                || identifier.length() > MAX_IDENTIFIER_LENGTH
+                || identifier.indexOf(':') >= 0
+                || identifier.chars().anyMatch(Character::isISOControl)
+                || secret == null
+                || secret.isBlank()
+                || secret.length() > MAX_SECRET_LENGTH) {
             throw new IllegalArgumentException("registry identifier and secret are required");
         }
     }

--- a/src/main/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClient.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClient.java
@@ -106,7 +106,7 @@ public final class DockerHubRegistryClient implements RegistryClient {
                     "identifier", registryCredentials.identifier(),
                     "secret", registryCredentials.secret()));
         } catch (JsonProcessingException exception) {
-            throw new RegistryException("could not create Docker Hub authentication request", exception);
+            throw new RegistryException("could not create Docker Hub authentication request");
         }
         HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("v2/auth/token"))
                 .timeout(requestTimeout)
@@ -135,13 +135,17 @@ public final class DockerHubRegistryClient implements RegistryClient {
                 if (body.length > MAX_RESPONSE_BYTES) {
                     throw new RegistryException(operation + " returned too much data");
                 }
-                return objectMapper.readTree(body);
+                try {
+                    return objectMapper.readTree(body);
+                } catch (IOException exception) {
+                    throw new RegistryException(operation + " returned invalid JSON");
+                }
             }
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             throw new RegistryException(operation + " was interrupted", exception);
         } catch (IOException exception) {
-            throw new RegistryException(operation + " failed", exception);
+            throw new RegistryException(operation + " response could not be read", exception);
         }
     }
 

--- a/src/main/java/io/github/ocularminds/blazra/registry/OciRegistryClient.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/OciRegistryClient.java
@@ -8,14 +8,19 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import io.github.ocularminds.blazra.model.RegistryCredentials;
 import io.github.ocularminds.blazra.model.RegistryRepository;
+import io.github.ocularminds.blazra.registry.auth.RegistryCredentialProvider;
 
 public final class OciRegistryClient implements RegistryClient {
     private static final int MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
@@ -27,6 +32,7 @@ public final class OciRegistryClient implements RegistryClient {
             "<([^<>]+)>\\s*;[^,]*?\\brel\\s*=\\s*\"?next\"?",
             Pattern.CASE_INSENSITIVE);
     private static final int MAX_TOKEN_LENGTH = 16 * 1024;
+    private static final int MAX_AUTH_CHALLENGE_LENGTH = 2048;
     private static final Pattern BEARER_TOKEN = Pattern.compile("[A-Za-z0-9\\-._~+/]+=*");
     private static final Pattern TAG = Pattern.compile("[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}");
 
@@ -34,8 +40,16 @@ public final class OciRegistryClient implements RegistryClient {
     private final ObjectMapper objectMapper;
     private final Function<RegistryRepository, URI> endpointResolver;
     private final Duration requestTimeout;
+    private final RegistryCredentialProvider credentialProvider;
 
     public OciRegistryClient(Duration connectTimeout, Duration requestTimeout) {
+        this(connectTimeout, requestTimeout, RegistryCredentialProvider.anonymous());
+    }
+
+    public OciRegistryClient(
+            Duration connectTimeout,
+            Duration requestTimeout,
+            RegistryCredentialProvider credentialProvider) {
         this(
                 HttpClient.newBuilder()
                         .connectTimeout(connectTimeout)
@@ -43,7 +57,8 @@ public final class OciRegistryClient implements RegistryClient {
                         .build(),
                 new ObjectMapper(),
                 repository -> URI.create("https://" + repository.host() + "/"),
-                requestTimeout);
+                requestTimeout,
+                credentialProvider);
     }
 
     OciRegistryClient(
@@ -51,12 +66,29 @@ public final class OciRegistryClient implements RegistryClient {
             ObjectMapper objectMapper,
             Function<RegistryRepository, URI> endpointResolver,
             Duration requestTimeout) {
+        this(
+                httpClient,
+                objectMapper,
+                endpointResolver,
+                requestTimeout,
+                RegistryCredentialProvider.anonymous());
+    }
+
+    OciRegistryClient(
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            Function<RegistryRepository, URI> endpointResolver,
+            Duration requestTimeout,
+            RegistryCredentialProvider credentialProvider) {
         this.httpClient = Objects.requireNonNull(httpClient, "http client is required");
         this.objectMapper = Objects.requireNonNull(objectMapper, "object mapper is required");
         this.endpointResolver = Objects.requireNonNull(
                 endpointResolver,
                 "endpoint resolver is required");
         this.requestTimeout = Objects.requireNonNull(requestTimeout, "request timeout is required");
+        this.credentialProvider = Objects.requireNonNull(
+                credentialProvider,
+                "credential provider is required");
         if (requestTimeout.isZero() || requestTimeout.isNegative()) {
             throw new IllegalArgumentException("request timeout must be positive");
         }
@@ -68,21 +100,18 @@ public final class OciRegistryClient implements RegistryClient {
         URI baseUri = requireHttpBase(endpointResolver.apply(repository));
         URI page = baseUri.resolve(
                 "v2/" + repository.path() + "/tags/list?n=" + PAGE_SIZE);
-        String bearerToken = null;
+        String authorization = null;
         List<String> tags = new ArrayList<>();
 
         for (int pageNumber = 0; page != null && pageNumber < MAX_PAGES; pageNumber++) {
-            HttpResponse<InputStream> response = sendTagRequest(page, bearerToken);
-            if (response.statusCode() == 401 && bearerToken == null) {
+            HttpResponse<InputStream> response = sendTagRequest(page, authorization);
+            if (response.statusCode() == 401 && authorization == null) {
                 String challengeHeader = response.headers()
                         .firstValue("WWW-Authenticate")
                         .orElse(null);
                 close(response.body());
-                OciBearerChallenge challenge = OciBearerChallenge.parse(
-                        challengeHeader,
-                        baseUri);
-                bearerToken = requestToken(challenge);
-                response = sendTagRequest(page, bearerToken);
+                authorization = authorize(challengeHeader, baseUri, repository);
+                response = sendTagRequest(page, authorization);
             }
 
             String linkHeader = response.headers().firstValue("Link").orElse(null);
@@ -96,13 +125,33 @@ public final class OciRegistryClient implements RegistryClient {
         return List.copyOf(tags);
     }
 
-    private String requestToken(OciBearerChallenge challenge) throws RegistryException {
-        HttpRequest request = HttpRequest.newBuilder(challenge.tokenUri())
+    private String authorize(
+            String challengeHeader,
+            URI baseUri,
+            RegistryRepository repository) throws RegistryException {
+        if (hasScheme(challengeHeader, "Bearer")) {
+            OciBearerChallenge challenge = OciBearerChallenge.parse(challengeHeader, baseUri);
+            return "Bearer " + requestToken(challenge, repository);
+        }
+        if (hasScheme(challengeHeader, "Basic")) {
+            RegistryCredentials credentials = credentialProvider.credentialsFor(repository)
+                    .orElseThrow(() -> new RegistryException(
+                            "OCI registry requires credentials for the configured repository"));
+            return basicAuthorization(credentials);
+        }
+        throw new RegistryException("OCI registry returned an invalid authentication challenge");
+    }
+
+    private String requestToken(
+            OciBearerChallenge challenge,
+            RegistryRepository repository) throws RegistryException {
+        HttpRequest.Builder request = HttpRequest.newBuilder(challenge.tokenUri())
                 .timeout(requestTimeout)
                 .header("Accept", "application/json")
-                .GET()
-                .build();
-        JsonNode document = readJson(send(request, "request OCI registry token"),
+                .GET();
+        Optional<RegistryCredentials> credentials = credentialProvider.credentialsFor(repository);
+        credentials.ifPresent(value -> request.header("Authorization", basicAuthorization(value)));
+        JsonNode document = readJson(send(request.build(), "request OCI registry token"),
                 "request OCI registry token");
         if (document == null || !document.isObject()) {
             throw new RegistryException("OCI registry returned an invalid authentication token");
@@ -121,14 +170,14 @@ public final class OciRegistryClient implements RegistryClient {
         return selected;
     }
 
-    private HttpResponse<InputStream> sendTagRequest(URI page, String bearerToken)
+    private HttpResponse<InputStream> sendTagRequest(URI page, String authorization)
             throws RegistryException {
         HttpRequest.Builder builder = HttpRequest.newBuilder(page)
                 .timeout(requestTimeout)
                 .header("Accept", "application/json")
                 .GET();
-        if (bearerToken != null) {
-            builder.header("Authorization", "Bearer " + bearerToken);
+        if (authorization != null) {
+            builder.header("Authorization", authorization);
         }
         return send(builder.build(), "list OCI registry tags");
     }
@@ -155,9 +204,13 @@ public final class OciRegistryClient implements RegistryClient {
             if (body.length > MAX_RESPONSE_BYTES) {
                 throw new RegistryException(operation + " returned too much data");
             }
-            return objectMapper.readTree(body);
+            try {
+                return objectMapper.readTree(body);
+            } catch (IOException exception) {
+                throw new RegistryException(operation + " returned invalid JSON");
+            }
         } catch (IOException exception) {
-            throw new RegistryException(operation + " returned invalid JSON", exception);
+            throw new RegistryException(operation + " response could not be read", exception);
         }
     }
 
@@ -232,6 +285,20 @@ public final class OciRegistryClient implements RegistryClient {
         return value != null && value.isTextual() && !value.textValue().isBlank()
                 ? value.textValue()
                 : null;
+    }
+
+    private static boolean hasScheme(String challenge, String scheme) {
+        return challenge != null
+                && challenge.length() <= MAX_AUTH_CHALLENGE_LENGTH
+                && challenge.length() > scheme.length()
+                && challenge.regionMatches(true, 0, scheme, 0, scheme.length())
+                && Character.isWhitespace(challenge.charAt(scheme.length()));
+    }
+
+    private static String basicAuthorization(RegistryCredentials credentials) {
+        String value = credentials.identifier() + ":" + credentials.secret();
+        return "Basic " + Base64.getEncoder().encodeToString(
+                value.getBytes(StandardCharsets.UTF_8));
     }
 
     private static void close(InputStream input) throws RegistryException {

--- a/src/main/java/io/github/ocularminds/blazra/registry/auth/DockerConfigCredentialProvider.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/auth/DockerConfigCredentialProvider.java
@@ -1,0 +1,140 @@
+package io.github.ocularminds.blazra.registry.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import io.github.ocularminds.blazra.model.RegistryCredentials;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+import io.github.ocularminds.blazra.registry.RegistryException;
+
+public final class DockerConfigCredentialProvider implements RegistryCredentialProvider {
+    private static final int MAX_CONFIG_BYTES = 1024 * 1024;
+    private static final int MAX_ENCODED_AUTH_LENGTH = 24 * 1024;
+
+    private final Path configPath;
+    private final ObjectMapper objectMapper;
+
+    public DockerConfigCredentialProvider(Path configPath) {
+        this(configPath, new ObjectMapper());
+    }
+
+    DockerConfigCredentialProvider(Path configPath, ObjectMapper objectMapper) {
+        this.configPath = requireAbsolutePath(configPath);
+        this.objectMapper = Objects.requireNonNull(objectMapper, "object mapper is required");
+    }
+
+    @Override
+    public Optional<RegistryCredentials> credentialsFor(RegistryRepository repository)
+            throws RegistryException {
+        Objects.requireNonNull(repository, "registry repository is required");
+        JsonNode document = readConfig();
+        JsonNode auths = document.get("auths");
+        if (auths == null || !auths.isObject()) {
+            throw invalidConfig();
+        }
+
+        JsonNode entry = findExactHostEntry(auths, repository.host());
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (!entry.isObject()) {
+            throw invalidConfig();
+        }
+        JsonNode encoded = entry.get("auth");
+        if (encoded == null
+                || !encoded.isTextual()
+                || encoded.textValue().isBlank()
+                || encoded.textValue().length() > MAX_ENCODED_AUTH_LENGTH) {
+            throw invalidConfig();
+        }
+        return Optional.of(decodeCredentials(encoded.textValue()));
+    }
+
+    private JsonNode readConfig() throws RegistryException {
+        byte[] content;
+        try (InputStream input = Files.newInputStream(configPath)) {
+            content = input.readNBytes(MAX_CONFIG_BYTES + 1);
+        } catch (IOException exception) {
+            throw new RegistryException("could not read OCI registry credential file", exception);
+        }
+        if (content.length > MAX_CONFIG_BYTES) {
+            throw new RegistryException("OCI registry credential file is too large");
+        }
+        try {
+            JsonNode document = objectMapper.readTree(content);
+            if (document == null || !document.isObject()) {
+                throw invalidConfig();
+            }
+            return document;
+        } catch (IOException exception) {
+            throw invalidConfig();
+        }
+    }
+
+    private static JsonNode findExactHostEntry(JsonNode auths, String host)
+            throws RegistryException {
+        JsonNode selected = null;
+        for (String candidate : List.of(
+                host,
+                "https://" + host,
+                "https://" + host + "/",
+                "https://" + host + "/v1/")) {
+            JsonNode found = auths.get(candidate);
+            if (found != null) {
+                if (selected != null) {
+                    throw new RegistryException(
+                            "OCI registry credential file has ambiguous host entries");
+                }
+                selected = found;
+            }
+        }
+        return selected;
+    }
+
+    private static RegistryCredentials decodeCredentials(String encoded)
+            throws RegistryException {
+        try {
+            String decoded = decodeUtf8(Base64.getDecoder().decode(encoded));
+            int separator = decoded.indexOf(':');
+            if (separator <= 0 || separator == decoded.length() - 1) {
+                throw invalidConfig();
+            }
+            return new RegistryCredentials(
+                    decoded.substring(0, separator),
+                    decoded.substring(separator + 1));
+        } catch (IllegalArgumentException | CharacterCodingException exception) {
+            throw invalidConfig();
+        }
+    }
+
+    private static String decodeUtf8(byte[] value) throws CharacterCodingException {
+        return StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(value))
+                .toString();
+    }
+
+    private static Path requireAbsolutePath(Path value) {
+        Objects.requireNonNull(value, "credential file path is required");
+        if (!value.isAbsolute()) {
+            throw new IllegalArgumentException("credential file path must be absolute");
+        }
+        return value.normalize();
+    }
+
+    private static RegistryException invalidConfig() {
+        return new RegistryException("OCI registry credential file is invalid");
+    }
+}

--- a/src/main/java/io/github/ocularminds/blazra/registry/auth/RegistryCredentialProvider.java
+++ b/src/main/java/io/github/ocularminds/blazra/registry/auth/RegistryCredentialProvider.java
@@ -1,0 +1,20 @@
+package io.github.ocularminds.blazra.registry.auth;
+
+import java.util.Objects;
+import java.util.Optional;
+import io.github.ocularminds.blazra.model.RegistryCredentials;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+import io.github.ocularminds.blazra.registry.RegistryException;
+
+@FunctionalInterface
+public interface RegistryCredentialProvider {
+    Optional<RegistryCredentials> credentialsFor(RegistryRepository repository)
+            throws RegistryException;
+
+    static RegistryCredentialProvider anonymous() {
+        return repository -> {
+            Objects.requireNonNull(repository, "registry repository is required");
+            return Optional.empty();
+        };
+    }
+}

--- a/src/test/java/io/github/ocularminds/blazra/config/BlazraConfigTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/config/BlazraConfigTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,22 +25,26 @@ class BlazraConfigTest {
         assertEquals(Duration.ofSeconds(15), config.requestTimeout());
         assertFalse(config.dryRun());
         assertEquals(UpdatePolicy.PATCH, config.updatePolicy());
-        assertTrue(config.registryCredentials().isEmpty());
+        assertTrue(config.dockerHubCredentials().isEmpty());
+        assertTrue(config.ociRegistryConfigPath().isEmpty());
     }
 
     @Test
     void loadsEveryOverride() {
-        BlazraConfig config = BlazraConfig.fromEnvironment(Map.of(
-                "BLAZRA_NAMESPACE", "payments",
-                "BLAZRA_DEPLOYMENT", "api",
-                "BLAZRA_CONTAINER", "web",
-                "BLAZRA_POLL_INTERVAL", "PT30S",
-                "BLAZRA_CONNECT_TIMEOUT", "PT2S",
-                "BLAZRA_REQUEST_TIMEOUT", "PT8S",
-                "BLAZRA_DRY_RUN", "TRUE",
-                "BLAZRA_UPDATE_POLICY", "minor",
-                "DOCKER_HUB_USERNAME", "robot",
-                "DOCKER_HUB_TOKEN", "secret"));
+        BlazraConfig config = BlazraConfig.fromEnvironment(Map.ofEntries(
+                Map.entry("BLAZRA_NAMESPACE", "payments"),
+                Map.entry("BLAZRA_DEPLOYMENT", "api"),
+                Map.entry("BLAZRA_CONTAINER", "web"),
+                Map.entry("BLAZRA_POLL_INTERVAL", "PT30S"),
+                Map.entry("BLAZRA_CONNECT_TIMEOUT", "PT2S"),
+                Map.entry("BLAZRA_REQUEST_TIMEOUT", "PT8S"),
+                Map.entry("BLAZRA_DRY_RUN", "TRUE"),
+                Map.entry("BLAZRA_UPDATE_POLICY", "minor"),
+                Map.entry(
+                        "BLAZRA_OCI_REGISTRY_CONFIG_PATH",
+                        "/var/run/secrets/registry/config.json"),
+                Map.entry("DOCKER_HUB_USERNAME", "robot"),
+                Map.entry("DOCKER_HUB_TOKEN", "secret")));
 
         assertEquals("payments", config.target().namespace());
         assertEquals(Duration.ofSeconds(30), config.pollInterval());
@@ -47,7 +52,10 @@ class BlazraConfigTest {
         assertEquals(Duration.ofSeconds(8), config.requestTimeout());
         assertTrue(config.dryRun());
         assertEquals(UpdatePolicy.MINOR, config.updatePolicy());
-        assertEquals("robot", config.registryCredentials().orElseThrow().identifier());
+        assertEquals("robot", config.dockerHubCredentials().orElseThrow().identifier());
+        assertEquals(
+                Path.of("/var/run/secrets/registry/config.json"),
+                config.ociRegistryConfigPath().orElseThrow());
     }
 
     @Test
@@ -60,7 +68,8 @@ class BlazraConfigTest {
                 "KUBERT_CONNECT_TIMEOUT", "PT3S",
                 "KUBERT_REQUEST_TIMEOUT", "PT9S",
                 "KUBERT_DRY_RUN", "true",
-                "KUBERT_UPDATE_POLICY", "major"));
+                "KUBERT_UPDATE_POLICY", "major",
+                "KUBERT_OCI_REGISTRY_CONFIG_PATH", "/legacy/registry.json"));
 
         assertEquals("legacy", config.target().namespace());
         assertEquals(Duration.ofMinutes(1), config.pollInterval());
@@ -68,6 +77,9 @@ class BlazraConfigTest {
         assertEquals(Duration.ofSeconds(9), config.requestTimeout());
         assertTrue(config.dryRun());
         assertEquals(UpdatePolicy.MAJOR, config.updatePolicy());
+        assertEquals(
+                Path.of("/legacy/registry.json"),
+                config.ociRegistryConfigPath().orElseThrow());
     }
 
     @Test
@@ -95,6 +107,10 @@ class BlazraConfigTest {
                 "BLAZRA_DEPLOYMENT", "api",
                 "BLAZRA_CONTAINER", "web",
                 "DOCKER_HUB_USERNAME", "robot")));
+        assertThrows(IllegalArgumentException.class, () -> BlazraConfig.fromEnvironment(Map.of(
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web",
+                "BLAZRA_OCI_REGISTRY_CONFIG_PATH", "relative/config.json")));
     }
 
     @Test
@@ -119,5 +135,19 @@ class BlazraConfigTest {
                 "BLAZRA_CONTAINER", "web",
                 "BLAZRA_POLL_INTERVAL", "five minutes");
         assertThrows(IllegalArgumentException.class, () -> BlazraConfig.fromEnvironment(malformed));
+        Map<String, String> oversizedPath = Map.of(
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web",
+                "BLAZRA_OCI_REGISTRY_CONFIG_PATH", "/" + "a".repeat(4096));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BlazraConfig.fromEnvironment(oversizedPath));
+        Map<String, String> invalidPath = Map.of(
+                "BLAZRA_DEPLOYMENT", "api",
+                "BLAZRA_CONTAINER", "web",
+                "BLAZRA_OCI_REGISTRY_CONFIG_PATH", "/bad\u0000path");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> BlazraConfig.fromEnvironment(invalidPath));
     }
 }

--- a/src/test/java/io/github/ocularminds/blazra/model/DeploymentModelsTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/model/DeploymentModelsTest.java
@@ -33,5 +33,17 @@ class DeploymentModelsTest {
         RegistryCredentials credentials = new RegistryCredentials("robot", "very-secret");
         assertFalse(credentials.toString().contains("very-secret"));
         assertThrows(IllegalArgumentException.class, () -> new RegistryCredentials("robot", ""));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RegistryCredentials("bad:user", "token"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RegistryCredentials("bad\nuser", "token"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RegistryCredentials("a".repeat(257), "token"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RegistryCredentials("robot", "a".repeat(16 * 1024 + 1)));
     }
 }

--- a/src/test/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClientTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/DockerHubRegistryClientTest.java
@@ -1,6 +1,7 @@
 package io.github.ocularminds.blazra.registry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -97,16 +98,18 @@ class DockerHubRegistryClientTest {
     @Test
     void rejectsMalformedAndUnsafeResponses() {
         server.createContext("/v2/namespaces/team/repositories/bad-json/tags", exchange ->
-                respond(exchange, 200, "not-json"));
+                respond(exchange, 200, "visible-secret-not-json"));
         server.createContext("/v2/namespaces/team/repositories/bad-results/tags", exchange ->
                 respond(exchange, 200, "{\"next\":null,\"results\":{}}"));
         server.createContext("/v2/namespaces/team/repositories/unsafe-next/tags", exchange ->
                 respond(exchange, 200, "{\"next\":\"https://attacker.example/tags\",\"results\":[]}"));
 
         DockerHubRegistryClient client = client(Optional.empty());
-        assertThrows(
+        RegistryException malformed = assertThrows(
                 RegistryException.class,
                 () -> client.listTags(repository("team/bad-json")));
+        assertTrue(!malformed.getMessage().contains("visible-secret"));
+        assertNull(malformed.getCause());
         assertThrows(
                 RegistryException.class,
                 () -> client.listTags(repository("team/bad-results")));

--- a/src/test/java/io/github/ocularminds/blazra/registry/OciRegistryClientTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/OciRegistryClientTest.java
@@ -1,6 +1,7 @@
 package io.github.ocularminds.blazra.registry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,13 +14,17 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import io.github.ocularminds.blazra.model.RegistryCredentials;
 import io.github.ocularminds.blazra.model.RegistryRepository;
+import io.github.ocularminds.blazra.registry.auth.RegistryCredentialProvider;
 
 class OciRegistryClientTest {
     private HttpServer server;
@@ -61,6 +66,7 @@ class OciRegistryClientTest {
         AtomicInteger tagRequests = new AtomicInteger();
         AtomicReference<String> tokenQuery = new AtomicReference<>();
         server.createContext("/token", exchange -> {
+            assertNull(exchange.getRequestHeaders().getFirst("Authorization"));
             tokenQuery.set(exchange.getRequestURI().getQuery());
             respond(exchange, 200, "{\"access_token\":\"short-lived-token\"}");
         });
@@ -84,6 +90,69 @@ class OciRegistryClientTest {
         assertEquals(2, tagRequests.get());
         assertTrue(tokenQuery.get().contains("service=registry.example"));
         assertTrue(tokenQuery.get().contains("scope=repository:team/app:pull"));
+    }
+
+    @Test
+    void usesHostScopedCredentialsOnlyAfterABearerChallenge() throws Exception {
+        AtomicInteger tagRequests = new AtomicInteger();
+        AtomicReference<String> tokenAuthorization = new AtomicReference<>();
+        server.createContext("/token-private", exchange -> {
+            tokenAuthorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, "{\"token\":\"private-bearer\"}");
+        });
+        server.createContext("/v2/private/app/tags/list", exchange -> {
+            tagRequests.incrementAndGet();
+            String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+            if (authorization == null) {
+                exchange.getResponseHeaders().set(
+                        "WWW-Authenticate",
+                        "Bearer realm=\"" + baseUri + "token-private\","
+                                + "service=\"registry.example\","
+                                + "scope=\"repository:private/app:pull\"");
+                respond(exchange, 401, "{}");
+            } else {
+                assertEquals("Bearer private-bearer", authorization);
+                respond(exchange, 200, "{\"name\":\"private/app\",\"tags\":[\"1.2\"]}");
+            }
+        });
+        RegistryCredentialProvider credentials = repository -> Optional.of(
+                new RegistryCredentials("robot", "private-token"));
+
+        assertEquals(
+                List.of("1.2"),
+                client(credentials).listTags(repository("private/app")));
+        assertEquals(2, tagRequests.get());
+        assertEquals(basic("robot:private-token"), tokenAuthorization.get());
+    }
+
+    @Test
+    void supportsNativeBasicAuthenticationAcrossPages() throws Exception {
+        AtomicInteger requests = new AtomicInteger();
+        server.createContext("/v2/basic/app/tags/list", exchange -> {
+            requests.incrementAndGet();
+            String authorization = exchange.getRequestHeaders().getFirst("Authorization");
+            if (authorization == null) {
+                exchange.getResponseHeaders().set("WWW-Authenticate", "Basic realm=\"private\"");
+                respond(exchange, 401, "{}");
+                return;
+            }
+            assertEquals(basic("robot:private-token"), authorization);
+            if (exchange.getRequestURI().getQuery().contains("last=1.0")) {
+                respond(exchange, 200, "{\"name\":\"basic/app\",\"tags\":[\"1.1\"]}");
+            } else {
+                exchange.getResponseHeaders().set(
+                        "Link",
+                        "</v2/basic/app/tags/list?n=100&last=1.0>; rel=\"next\"");
+                respond(exchange, 200, "{\"name\":\"basic/app\",\"tags\":[\"1.0\"]}");
+            }
+        });
+        RegistryCredentialProvider credentials = repository -> Optional.of(
+                new RegistryCredentials("robot", "private-token"));
+
+        assertEquals(
+                List.of("1.0", "1.1"),
+                client(credentials).listTags(repository("basic/app")));
+        assertEquals(3, requests.get());
     }
 
     @Test
@@ -124,10 +193,24 @@ class OciRegistryClientTest {
         challengeOnly("large/app", "token-large");
         server.createContext("/v2/missing/app/tags/list", exchange ->
                 respond(exchange, 401, "{}"));
+        server.createContext("/v2/basic/app/tags/list", exchange -> {
+            exchange.getResponseHeaders().set("WWW-Authenticate", "Basic realm=\"private\"");
+            respond(exchange, 401, "{}");
+        });
+        server.createContext("/v2/digest/app/tags/list", exchange -> {
+            exchange.getResponseHeaders().set("WWW-Authenticate", "Digest realm=\"private\"");
+            respond(exchange, 401, "{}");
+        });
+        server.createContext("/v2/large-challenge/app/tags/list", exchange -> {
+            exchange.getResponseHeaders().set(
+                    "WWW-Authenticate",
+                    "Basic " + "a".repeat(2049));
+            respond(exchange, 401, "{}");
+        });
 
         for (String path : new String[]{
                 "empty/app", "conflict/app", "malformed/app", "empty-body/app", "array/app",
-                "large/app", "missing/app"
+                "large/app", "missing/app", "basic/app", "digest/app", "large-challenge/app"
         }) {
             assertThrows(
                     RegistryException.class,
@@ -141,7 +224,7 @@ class OciRegistryClientTest {
         server.createContext("/v2/error/app/tags/list", exchange ->
                 respond(exchange, 500, "sensitive upstream details"));
         server.createContext("/v2/json/app/tags/list", exchange ->
-                respond(exchange, 200, "not-json"));
+                respond(exchange, 200, "visible-secret-not-json"));
         server.createContext("/v2/name/app/tags/list", exchange ->
                 respond(exchange, 200, "{\"name\":\"other/app\",\"tags\":[]}"));
         server.createContext("/v2/object/app/tags/list", exchange ->
@@ -158,8 +241,13 @@ class OciRegistryClientTest {
                 () -> client().listTags(repository("error/app")));
         assertTrue(failure.getMessage().contains("HTTP 500"));
         assertTrue(!failure.getMessage().contains("sensitive"));
+        RegistryException malformed = assertThrows(
+                RegistryException.class,
+                () -> client().listTags(repository("json/app")));
+        assertTrue(!malformed.getMessage().contains("visible-secret"));
+        assertNull(malformed.getCause());
         for (String path : new String[]{
-                "json/app", "name/app", "object/app", "element/app", "tag/app", "empty/app"
+                "name/app", "object/app", "element/app", "tag/app", "empty/app"
         }) {
             assertThrows(
                     RegistryException.class,
@@ -238,6 +326,14 @@ class OciRegistryClientTest {
                         new ObjectMapper(),
                         null,
                         Duration.ofSeconds(1)));
+        assertThrows(
+                NullPointerException.class,
+                () -> new OciRegistryClient(
+                        HttpClient.newHttpClient(),
+                        new ObjectMapper(),
+                        ignored -> baseUri,
+                        Duration.ofSeconds(1),
+                        null));
         assertThrows(NullPointerException.class, () -> client().listTags(null));
 
         server.createContext("/v2/team/app/tags/list", exchange ->
@@ -287,15 +383,25 @@ class OciRegistryClientTest {
     }
 
     private OciRegistryClient client() {
+        return client(RegistryCredentialProvider.anonymous());
+    }
+
+    private OciRegistryClient client(RegistryCredentialProvider credentialProvider) {
         return new OciRegistryClient(
                 HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(1)).build(),
                 new ObjectMapper(),
                 ignored -> baseUri,
-                Duration.ofSeconds(2));
+                Duration.ofSeconds(2),
+                credentialProvider);
     }
 
     private static RegistryRepository repository(String path) {
         return new RegistryRepository("registry.example", path);
+    }
+
+    private static String basic(String value) {
+        return "Basic " + Base64.getEncoder().encodeToString(
+                value.getBytes(StandardCharsets.UTF_8));
     }
 
     private static void respond(HttpExchange exchange, int status, String body) throws IOException {

--- a/src/test/java/io/github/ocularminds/blazra/registry/auth/DockerConfigCredentialProviderTest.java
+++ b/src/test/java/io/github/ocularminds/blazra/registry/auth/DockerConfigCredentialProviderTest.java
@@ -1,0 +1,181 @@
+package io.github.ocularminds.blazra.registry.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import io.github.ocularminds.blazra.model.RegistryCredentials;
+import io.github.ocularminds.blazra.model.RegistryRepository;
+import io.github.ocularminds.blazra.registry.RegistryException;
+
+class DockerConfigCredentialProviderTest {
+    @TempDir
+    private Path temporaryDirectory;
+
+    @Test
+    void readsOnlyCredentialsForTheExactRegistryHost() throws Exception {
+        Path config = writeConfig("""
+                {"auths":{
+                  "ghcr.io":{"auth":"%s"},
+                  "attacker-ghcr.io":{"auth":"%s"}
+                }}
+                """.formatted(
+                encoded("robot:secret:with:colons"),
+                encoded("attacker:wrong")));
+        DockerConfigCredentialProvider provider = new DockerConfigCredentialProvider(config);
+
+        RegistryCredentials credentials = provider.credentialsFor(repository("ghcr.io"))
+                .orElseThrow();
+
+        assertEquals("robot", credentials.identifier());
+        assertEquals("secret:with:colons", credentials.secret());
+        assertTrue(provider.credentialsFor(repository("registry.example")).isEmpty());
+    }
+
+    @Test
+    void acceptsStandardDockerConfigHostKeyForms() throws Exception {
+        for (String key : new String[]{
+                "registry.example",
+                "https://registry.example",
+                "https://registry.example/",
+                "https://registry.example/v1/"
+        }) {
+            Path config = writeConfig("""
+                    {"auths":{"%s":{"auth":"%s"}}}
+                    """.formatted(key, encoded("robot:token")));
+
+            assertEquals(
+                    "robot",
+                    new DockerConfigCredentialProvider(config)
+                            .credentialsFor(repository("registry.example"))
+                            .orElseThrow()
+                            .identifier(),
+                    key);
+        }
+    }
+
+    @Test
+    void rereadsProjectedSecretsToSupportCredentialRotation() throws Exception {
+        Path config = writeConfig(configWithAuth("registry.example", "robot:first"));
+        DockerConfigCredentialProvider provider = new DockerConfigCredentialProvider(config);
+        assertEquals(
+                "first",
+                provider.credentialsFor(repository("registry.example")).orElseThrow().secret());
+
+        Files.writeString(
+                config,
+                configWithAuth("registry.example", "robot:second"),
+                StandardCharsets.UTF_8);
+
+        assertEquals(
+                "second",
+                provider.credentialsFor(repository("registry.example")).orElseThrow().secret());
+    }
+
+    @Test
+    void rejectsMalformedOrAmbiguousCredentialDocumentsWithoutLeakingThem() throws Exception {
+        for (String invalid : new String[]{
+                "",
+                "[]",
+                "{\"secret\":\"visible-value\"}",
+                "{\"auths\":[]}",
+                "{\"auths\":{\"registry.example\":[]}}",
+                "{\"auths\":{\"registry.example\":{\"auth\":1}}}",
+                configWithEncodedAuth("registry.example", ""),
+                configWithEncodedAuth("registry.example", "not-base64"),
+                configWithEncodedAuth("registry.example", encoded("missing-separator")),
+                configWithEncodedAuth("registry.example", encoded("robot:")),
+                configWithEncodedAuth(
+                        "registry.example",
+                        Base64.getEncoder().encodeToString(new byte[]{(byte) 0xc3, (byte) 0x28})),
+                "{\"auths\":{"
+                        + "\"registry.example\":{\"auth\":\"" + encoded("one:first") + "\"},"
+                        + "\"https://registry.example\":{\"auth\":\""
+                        + encoded("two:second") + "\"}}}"
+        }) {
+            Path config = writeConfig(invalid);
+            RegistryException exception = assertThrows(
+                    RegistryException.class,
+                    () -> new DockerConfigCredentialProvider(config)
+                            .credentialsFor(repository("registry.example")));
+
+            assertFalse(exception.getMessage().contains("visible-value"));
+            assertNull(exception.getCause());
+        }
+    }
+
+    @Test
+    void boundsFilesAndCredentialEntries() throws Exception {
+        Path oversizedFile = writeConfig(" ".repeat(1024 * 1024 + 1));
+        assertThrows(
+                RegistryException.class,
+                () -> new DockerConfigCredentialProvider(oversizedFile)
+                        .credentialsFor(repository("registry.example")));
+
+        Path oversizedAuth = writeConfig(configWithEncodedAuth(
+                "registry.example",
+                "a".repeat(24 * 1024 + 1)));
+        assertThrows(
+                RegistryException.class,
+                () -> new DockerConfigCredentialProvider(oversizedAuth)
+                        .credentialsFor(repository("registry.example")));
+    }
+
+    @Test
+    void validatesPathsAndReportsUnreadableFilesSafely() {
+        assertThrows(
+                NullPointerException.class,
+                () -> new DockerConfigCredentialProvider(null));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new DockerConfigCredentialProvider(Path.of("relative.json")));
+
+        Path missing = temporaryDirectory.resolve("missing.json");
+        RegistryException exception = assertThrows(
+                RegistryException.class,
+                () -> new DockerConfigCredentialProvider(missing)
+                        .credentialsFor(repository("registry.example")));
+        assertTrue(exception.getMessage().contains("could not read"));
+        assertThrows(
+                NullPointerException.class,
+                () -> new DockerConfigCredentialProvider(missing).credentialsFor(null));
+    }
+
+    @Test
+    void anonymousProviderNeverReturnsCredentials() throws Exception {
+        RegistryCredentialProvider provider = RegistryCredentialProvider.anonymous();
+        assertTrue(provider.credentialsFor(repository("registry.example")).isEmpty());
+        assertThrows(NullPointerException.class, () -> provider.credentialsFor(null));
+    }
+
+    private Path writeConfig(String content) throws IOException {
+        Path config = temporaryDirectory.resolve("config.json");
+        Files.writeString(config, content, StandardCharsets.UTF_8);
+        return config;
+    }
+
+    private static String configWithAuth(String host, String credentials) {
+        return configWithEncodedAuth(host, encoded(credentials));
+    }
+
+    private static String configWithEncodedAuth(String host, String auth) {
+        return "{\"auths\":{\"" + host + "\":{\"auth\":\"" + auth + "\"}}}";
+    }
+
+    private static String encoded(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static RegistryRepository repository(String host) {
+        return new RegistryRepository(host, "team/app");
+    }
+}


### PR DESCRIPTION
## Summary

- add private OCI repository authentication through a standard Kubernetes `.dockerconfigjson` Secret
- introduce a single-purpose credential provider that resolves entries by exact registry host and rereads projected files for rotation
- support both OCI Bearer token exchanges authenticated with Basic credentials and native Basic registry challenges
- keep the existing Docker Hub authentication adapter and Secret values backward compatible
- document and test the Helm configuration for sharing one pull Secret with the kubelet and Blazra

## Security and performance

- never send OCI credentials before the registry returns an authentication challenge
- keep credentials scoped to the challenged repository host and the existing same-origin HTTPS token-service policy
- mount the Docker config only into the Blazra sidecar, not the primary workload
- bound credential files and decoded values, reject malformed or ambiguous host entries, and redact parser failures
- remove upstream JSON parser causes that could expose response fragments in logs
- read the credential file only when authentication is required, while supporting projected Secret rotation

The flow follows the CNCF Distribution token-authentication model: https://distribution.github.io/distribution/spec/auth/token/

## Validation

- `./gradlew clean check installDist --no-daemon`
- JaCoCo: 808/867 lines (93.2%), 462/530 branches (87.2%)
- Helm lint/render tests for anonymous, Docker Hub, and private OCI configurations
- release and security-automation contract tests
- ShellCheck and actionlint
- live public-registry regression smoke tests against `ghcr.io/ocularminds/blazra` and `public.ecr.aws/amazonlinux/amazonlinux`
- largest Java file: 414 LOC; largest production Java file: 311 LOC
